### PR TITLE
Topic config by component

### DIFF
--- a/autoconfigure/README.md
+++ b/autoconfigure/README.md
@@ -9,6 +9,9 @@
 | `KAFKA_TRACE_TOPIC` | Topic where aggregated traces are stored. | `zipkin-trace` |
 | `KAFKA_DEPENDENCY_TOPIC` | Topic where aggregated service dependencies names are stored. | `zipkin-dependency` |
 
+> These topics can be configured by individual components (span-consumer, aggregation, storage) by using Java options. 
+> For more information about property names, check [zipkin-server-kafka.yml](src/main/resources/zipkin-server-kafka.yml)
+
 ## Storage configurations
 
 | Configuration | Description | Default |

--- a/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -41,8 +41,8 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   private String aggregationSpansTopic;
   private String aggregationTraceTopic;
   private String aggregationDependencyTopic;
-  private String storeSpansTopic;
-  private String storeDependencyTopic;
+  private String storageSpansTopic;
+  private String storageDependencyTopic;
 
   private String storageDir;
 
@@ -88,8 +88,8 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     if (aggregationDependencyTopic != null) {
       builder.aggregationDependencyTopic(aggregationDependencyTopic);
     }
-    if (storeSpansTopic != null) builder.storeSpansTopic(storeSpansTopic);
-    if (storeDependencyTopic != null) builder.storeDependencyTopic(storeDependencyTopic);
+    if (storageSpansTopic != null) builder.storageSpansTopic(storageSpansTopic);
+    if (storageDependencyTopic != null) builder.storageDependencyTopic(storageDependencyTopic);
     if (adminOverrides != null) builder.adminOverrides(adminOverrides);
     if (producerOverrides != null) builder.producerOverrides(producerOverrides);
     if (aggregationStreamOverrides != null) {
@@ -271,19 +271,19 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     this.partitionedSpansTopic = partitionedSpansTopic;
   }
 
-  public String getStoreSpansTopic() {
-    return storeSpansTopic;
+  public String getStorageSpansTopic() {
+    return storageSpansTopic;
   }
 
-  public void setStoreSpansTopic(String storeSpansTopic) {
-    this.storeSpansTopic = storeSpansTopic;
+  public void setStorageSpansTopic(String storageSpansTopic) {
+    this.storageSpansTopic = storageSpansTopic;
   }
 
-  public String getStoreDependencyTopic() {
-    return storeDependencyTopic;
+  public String getStorageDependencyTopic() {
+    return storageDependencyTopic;
   }
 
-  public void setStoreDependencyTopic(String storeDependencyTopic) {
-    this.storeDependencyTopic = storeDependencyTopic;
+  public void setStorageDependencyTopic(String storageDependencyTopic) {
+    this.storageDependencyTopic = storageDependencyTopic;
   }
 }

--- a/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -218,8 +218,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return aggregationStreamOverrides;
   }
 
-  public void setAggregationStreamOverrides(
-    Map<String, String> aggregationStreamOverrides) {
+  public void setAggregationStreamOverrides(Map<String, String> aggregationStreamOverrides) {
     this.aggregationStreamOverrides = aggregationStreamOverrides;
   }
 
@@ -227,8 +226,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return traceStoreStreamOverrides;
   }
 
-  public void setTraceStoreStreamOverrides(
-    Map<String, String> traceStoreStreamOverrides) {
+  public void setTraceStoreStreamOverrides(Map<String, String> traceStoreStreamOverrides) {
     this.traceStoreStreamOverrides = traceStoreStreamOverrides;
   }
 
@@ -237,7 +235,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setDependencyStoreStreamOverrides(
-    Map<String, String> dependencyStoreStreamOverrides) {
+      Map<String, String> dependencyStoreStreamOverrides) {
     this.dependencyStoreStreamOverrides = dependencyStoreStreamOverrides;
   }
 

--- a/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/autoconfigure/src/main/java/zipkin2/autoconfigure/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -37,9 +37,12 @@ public class ZipkinKafkaStorageProperties implements Serializable {
 
   private Long dependencyTtl;
 
-  private String spansTopic;
-  private String traceTopic;
-  private String dependencyTopic;
+  private String partitionedSpansTopic;
+  private String aggregationSpansTopic;
+  private String aggregationTraceTopic;
+  private String aggregationDependencyTopic;
+  private String storeSpansTopic;
+  private String storeDependencyTopic;
 
   private String storageDir;
 
@@ -79,9 +82,14 @@ public class ZipkinKafkaStorageProperties implements Serializable {
       builder.aggregationStreamAppId(dependencyStoreStreamAppId);
     }
     if (storageDir != null) builder.storageDir(storageDir);
-    if (spansTopic != null) builder.spansTopicName(spansTopic);
-    if (traceTopic != null) builder.tracesTopicName(traceTopic);
-    if (dependencyTopic != null) builder.dependenciesTopicName(dependencyTopic);
+    if (partitionedSpansTopic != null) builder.partitionedSpansTopic(partitionedSpansTopic);
+    if (aggregationSpansTopic != null) builder.aggregationSpansTopic(aggregationSpansTopic);
+    if (aggregationTraceTopic != null) builder.aggregationTraceTopic(aggregationTraceTopic);
+    if (aggregationDependencyTopic != null) {
+      builder.aggregationDependencyTopic(aggregationDependencyTopic);
+    }
+    if (storeSpansTopic != null) builder.storeSpansTopic(storeSpansTopic);
+    if (storeDependencyTopic != null) builder.storeDependencyTopic(storeDependencyTopic);
     if (adminOverrides != null) builder.adminOverrides(adminOverrides);
     if (producerOverrides != null) builder.producerOverrides(producerOverrides);
     if (aggregationStreamOverrides != null) {
@@ -150,28 +158,28 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     this.traceTimeout = traceTimeout;
   }
 
-  public String getSpansTopic() {
-    return spansTopic;
+  public String getAggregationSpansTopic() {
+    return aggregationSpansTopic;
   }
 
-  public void setSpansTopic(String spansTopic) {
-    this.spansTopic = spansTopic;
+  public void setAggregationSpansTopic(String aggregationSpansTopic) {
+    this.aggregationSpansTopic = aggregationSpansTopic;
   }
 
-  public String getTraceTopic() {
-    return traceTopic;
+  public String getAggregationTraceTopic() {
+    return aggregationTraceTopic;
   }
 
-  public void setTraceTopic(String traceTopic) {
-    this.traceTopic = traceTopic;
+  public void setAggregationTraceTopic(String aggregationTraceTopic) {
+    this.aggregationTraceTopic = aggregationTraceTopic;
   }
 
-  public String getDependencyTopic() {
-    return dependencyTopic;
+  public String getAggregationDependencyTopic() {
+    return aggregationDependencyTopic;
   }
 
-  public void setDependencyTopic(String dependencyTopic) {
-    this.dependencyTopic = dependencyTopic;
+  public void setAggregationDependencyTopic(String aggregationDependencyTopic) {
+    this.aggregationDependencyTopic = aggregationDependencyTopic;
   }
 
   public String getStorageDir() {
@@ -211,7 +219,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setAggregationStreamOverrides(
-      Map<String, String> aggregationStreamOverrides) {
+    Map<String, String> aggregationStreamOverrides) {
     this.aggregationStreamOverrides = aggregationStreamOverrides;
   }
 
@@ -220,7 +228,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setTraceStoreStreamOverrides(
-      Map<String, String> traceStoreStreamOverrides) {
+    Map<String, String> traceStoreStreamOverrides) {
     this.traceStoreStreamOverrides = traceStoreStreamOverrides;
   }
 
@@ -229,7 +237,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setDependencyStoreStreamOverrides(
-      Map<String, String> dependencyStoreStreamOverrides) {
+    Map<String, String> dependencyStoreStreamOverrides) {
     this.dependencyStoreStreamOverrides = dependencyStoreStreamOverrides;
   }
 
@@ -255,5 +263,29 @@ public class ZipkinKafkaStorageProperties implements Serializable {
 
   public void setDependencyStoreStreamAppId(String dependencyStoreStreamAppId) {
     this.dependencyStoreStreamAppId = dependencyStoreStreamAppId;
+  }
+
+  public String getPartitionedSpansTopic() {
+    return partitionedSpansTopic;
+  }
+
+  public void setPartitionedSpansTopic(String partitionedSpansTopic) {
+    this.partitionedSpansTopic = partitionedSpansTopic;
+  }
+
+  public String getStoreSpansTopic() {
+    return storeSpansTopic;
+  }
+
+  public void setStoreSpansTopic(String storeSpansTopic) {
+    this.storeSpansTopic = storeSpansTopic;
+  }
+
+  public String getStoreDependencyTopic() {
+    return storeDependencyTopic;
+  }
+
+  public void setStoreDependencyTopic(String storeDependencyTopic) {
+    this.storeDependencyTopic = storeDependencyTopic;
   }
 }

--- a/autoconfigure/src/main/resources/zipkin-server-kafka.yml
+++ b/autoconfigure/src/main/resources/zipkin-server-kafka.yml
@@ -6,9 +6,12 @@ zipkin:
       # Connection to Kafka
       bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
       # Kafka topic names
-      spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
-      trace-topic: ${KAFKA_TRACE_TOPIC:zipkin-trace}
-      dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
+      partitioned-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
+      aggregation-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
+      aggregation-trace-topic: ${KAFKA_TRACE_TOPIC:zipkin-trace}
+      aggregation-dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
+      store-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
+      store-dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
       # Kafka Streams configs
       aggregation-stream-app-id: ${KAFKA_STORAGE_AGGREGATION_STREAM_APP_ID:zipkin-aggregation}
       trace-store-stream-app-id: ${KAFKA_STORAGE_TRACE_STORE_STREAM_APP_ID:zipkin-trace-store}

--- a/autoconfigure/src/main/resources/zipkin-server-kafka.yml
+++ b/autoconfigure/src/main/resources/zipkin-server-kafka.yml
@@ -10,8 +10,8 @@ zipkin:
       aggregation-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
       aggregation-trace-topic: ${KAFKA_TRACE_TOPIC:zipkin-trace}
       aggregation-dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
-      store-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
-      store-dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
+      storage-spans-topic: ${KAFKA_SPANS_TOPIC:zipkin-spans}
+      storage-dependency-topic: ${KAFKA_DEPENDENCY_TOPIC:zipkin-dependency}
       # Kafka Streams configs
       aggregation-stream-app-id: ${KAFKA_STORAGE_AGGREGATION_STREAM_APP_ID:zipkin-aggregation}
       trace-store-stream-app-id: ${KAFKA_STORAGE_TRACE_STORE_STREAM_APP_ID:zipkin-trace-store}

--- a/autoconfigure/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageAutoConfigurationTest.java
+++ b/autoconfigure/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageAutoConfigurationTest.java
@@ -183,27 +183,27 @@ public class ZipkinKafkaStorageAutoConfigurationTest {
         "zipkin-dependencies-1");
   }
 
-  @Test void canOverridesProperty_storeSpansTopic() {
+  @Test void canOverridesProperty_storageSpansTopic() {
     TestPropertyValues.of(
         "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.store-spans-topic:zipkin-spans-1"
+        "zipkin.storage.kafka.storage-spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).storeSpansTopic).isEqualTo(
+    assertThat(context.getBean(KafkaStorage.class).storageSpansTopic).isEqualTo(
         "zipkin-spans-1");
   }
 
-  @Test void canOverridesProperty_storeDependencyTopic() {
+  @Test void canOverridesProperty_storageDependencyTopic() {
     TestPropertyValues.of(
         "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.store-dependency-topic:zipkin-dependencies-1"
+        "zipkin.storage.kafka.storage-dependency-topic:zipkin-dependencies-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).storeDependencyTopic).isEqualTo(
+    assertThat(context.getBean(KafkaStorage.class).storageDependencyTopic).isEqualTo(
         "zipkin-dependencies-1");
   }
 

--- a/autoconfigure/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageAutoConfigurationTest.java
+++ b/autoconfigure/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageAutoConfigurationTest.java
@@ -135,37 +135,75 @@ public class ZipkinKafkaStorageAutoConfigurationTest {
     assertThat(context.getBean(KafkaStorage.class).storageDir).isEqualTo("/zipkin");
   }
 
-  @Test void canOverridesProperty_spansTopicName() {
+  @Test void canOverridesProperty_partitionedSpansTopic() {
     TestPropertyValues.of(
         "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.spans-topic:zipkin-spans-1"
+        "zipkin.storage.kafka.partitioned-spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).spansTopicName).isEqualTo("zipkin-spans-1");
+    assertThat(context.getBean(KafkaStorage.class).partitionedSpansTopic).isEqualTo(
+        "zipkin-spans-1");
   }
 
-  @Test void canOverridesProperty_tracesTopicName() {
+  @Test void canOverridesProperty_aggregationSpansTopic() {
     TestPropertyValues.of(
         "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.trace-topic:zipkin-traces-1"
+        "zipkin.storage.kafka.aggregation-spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).traceTopicName).isEqualTo("zipkin-traces-1");
+    assertThat(context.getBean(KafkaStorage.class).aggregationSpansTopic).isEqualTo(
+        "zipkin-spans-1");
   }
 
-  @Test void canOverridesProperty_dependenciesTopicName() {
+  @Test void canOverridesProperty_aggregationTraceTopic() {
     TestPropertyValues.of(
         "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.dependency-topic:zipkin-dependencies-1"
+        "zipkin.storage.kafka.aggregation-trace-topic:zipkin-traces-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).dependencyTopicName).isEqualTo(
+    assertThat(context.getBean(KafkaStorage.class).aggregationTraceTopic).isEqualTo(
+        "zipkin-traces-1");
+  }
+
+  @Test void canOverridesProperty_aggregationDependencyTopic() {
+    TestPropertyValues.of(
+        "zipkin.storage.type:kafka",
+        "zipkin.storage.kafka.aggregation-dependency-topic:zipkin-dependencies-1"
+    ).applyTo(context);
+    Access.registerKafka(context);
+    context.refresh();
+
+    assertThat(context.getBean(KafkaStorage.class).aggregationDependencyTopic).isEqualTo(
+        "zipkin-dependencies-1");
+  }
+
+  @Test void canOverridesProperty_storeSpansTopic() {
+    TestPropertyValues.of(
+        "zipkin.storage.type:kafka",
+        "zipkin.storage.kafka.store-spans-topic:zipkin-spans-1"
+    ).applyTo(context);
+    Access.registerKafka(context);
+    context.refresh();
+
+    assertThat(context.getBean(KafkaStorage.class).storeSpansTopic).isEqualTo(
+        "zipkin-spans-1");
+  }
+
+  @Test void canOverridesProperty_storeDependencyTopic() {
+    TestPropertyValues.of(
+        "zipkin.storage.type:kafka",
+        "zipkin.storage.kafka.store-dependency-topic:zipkin-dependencies-1"
+    ).applyTo(context);
+    Access.registerKafka(context);
+    context.refresh();
+
+    assertThat(context.getBean(KafkaStorage.class).storeDependencyTopic).isEqualTo(
         "zipkin-dependencies-1");
   }
 
@@ -177,7 +215,6 @@ public class ZipkinKafkaStorageAutoConfigurationTest {
     Access.registerKafka(context);
     context.refresh();
 
-    assertThat(context.getBean(KafkaStorage.class).hostname).isEqualTo(
-      "other_host");
+    assertThat(context.getBean(KafkaStorage.class).hostname).isEqualTo("other_host");
   }
 }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
@@ -30,8 +30,8 @@ import zipkin2.storage.kafka.internal.AwaitableCallback;
 /**
  * Span Consumer to compensate current {@code zipkin2.reporter.kafka.KafkaSender} distribution of
  * span batched without key.
- *
- * <p> This component split batch into individual spans keyed by trace ID to enabled downstream
+ * <p>
+ * This component split batch into individual spans keyed by trace ID to enabled downstream
  * processing of spans as part of a trace.
  */
 final class KafkaSpanConsumer implements SpanConsumer {
@@ -41,7 +41,7 @@ final class KafkaSpanConsumer implements SpanConsumer {
   final Producer<String, byte[]> producer;
 
   KafkaSpanConsumer(KafkaStorage storage) {
-    spansTopicName = storage.spansTopicName;
+    spansTopicName = storage.partitionedSpansTopic;
     producer = storage.getProducer();
   }
 

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
@@ -69,7 +69,9 @@ public class KafkaStorage extends StorageComponent {
   final String hostname;
   final int httpPort;
   // Kafka Topics
-  final String spansTopicName, traceTopicName, dependencyTopicName;
+  final String partitionedSpansTopic;
+  final String aggregationSpansTopic, aggregationTraceTopic, aggregationDependencyTopic;
+  final String storeSpansTopic, storeDependencyTopic;
   // Kafka Clients config
   final Properties adminConfig;
   final Properties producerConfig;
@@ -91,9 +93,12 @@ public class KafkaStorage extends StorageComponent {
     // Autocomplete tags
     this.autocompleteKeys = builder.autocompleteKeys;
     // Kafka Topics config
-    this.spansTopicName = builder.spansTopicName;
-    this.traceTopicName = builder.traceTopicName;
-    this.dependencyTopicName = builder.dependencyTopicName;
+    this.partitionedSpansTopic = builder.partitionedSpansTopic;
+    this.aggregationSpansTopic = builder.aggregationSpansTopic;
+    this.aggregationTraceTopic = builder.aggregationTraceTopic;
+    this.aggregationDependencyTopic = builder.aggregationDependencyTopic;
+    this.storeSpansTopic = builder.storeSpansTopic;
+    this.storeDependencyTopic = builder.storeDependencyTopic;
     // Storage directories
     this.storageDir = builder.storageDir;
     this.minTracesStored = builder.minTracesStored;
@@ -108,18 +113,18 @@ public class KafkaStorage extends StorageComponent {
     this.dependencyStoreStreamConfig = builder.dependencyStoreStreamConfig;
 
     aggregationTopology = new AggregationTopologySupplier(
-        spansTopicName,
-        traceTopicName,
-        dependencyTopicName,
+        aggregationSpansTopic,
+        aggregationTraceTopic,
+        aggregationDependencyTopic,
         builder.traceTimeout).get();
     traceStoreTopology = new TraceStoreTopologySupplier(
-        spansTopicName,
+        storeSpansTopic,
         autocompleteKeys,
         builder.traceTtl,
         builder.traceTtlCheckInterval,
         builder.minTracesStored).get();
     dependencyStoreTopology = new DependencyStoreTopologySupplier(
-        dependencyTopicName,
+        storeDependencyTopic,
         builder.dependencyTtl,
         builder.dependencyWindowSize).get();
   }
@@ -344,9 +349,6 @@ public class KafkaStorage extends StorageComponent {
         ", spanConsumerEnabled=" + spanConsumerEnabled +
         ", searchEnabled=" + searchEnabled +
         ", storageDir='" + storageDir + '\'' +
-        ", spansTopicName='" + spansTopicName + '\'' +
-        ", traceTopicName='" + traceTopicName + '\'' +
-        ", dependencyTopicName='" + dependencyTopicName + '\'' +
         '}';
   }
 }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
@@ -71,7 +71,7 @@ public class KafkaStorage extends StorageComponent {
   // Kafka Topics
   final String partitionedSpansTopic;
   final String aggregationSpansTopic, aggregationTraceTopic, aggregationDependencyTopic;
-  final String storeSpansTopic, storeDependencyTopic;
+  final String storageSpansTopic, storageDependencyTopic;
   // Kafka Clients config
   final Properties adminConfig;
   final Properties producerConfig;
@@ -97,8 +97,8 @@ public class KafkaStorage extends StorageComponent {
     this.aggregationSpansTopic = builder.aggregationSpansTopic;
     this.aggregationTraceTopic = builder.aggregationTraceTopic;
     this.aggregationDependencyTopic = builder.aggregationDependencyTopic;
-    this.storeSpansTopic = builder.storeSpansTopic;
-    this.storeDependencyTopic = builder.storeDependencyTopic;
+    this.storageSpansTopic = builder.storageSpansTopic;
+    this.storageDependencyTopic = builder.storageDependencyTopic;
     // Storage directories
     this.storageDir = builder.storageDir;
     this.minTracesStored = builder.minTracesStored;
@@ -118,13 +118,13 @@ public class KafkaStorage extends StorageComponent {
         aggregationDependencyTopic,
         builder.traceTimeout).get();
     traceStoreTopology = new TraceStoreTopologySupplier(
-        storeSpansTopic,
+        storageSpansTopic,
         autocompleteKeys,
         builder.traceTtl,
         builder.traceTtlCheckInterval,
         builder.minTracesStored).get();
     dependencyStoreTopology = new DependencyStoreTopologySupplier(
-        storeDependencyTopic,
+        storageDependencyTopic,
         builder.dependencyTtl,
         builder.dependencyWindowSize).get();
   }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
@@ -13,8 +13,6 @@
  */
 package zipkin2.storage.kafka;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,9 +58,12 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
   String dependencyStoreStreamAppId = "zipkin-dependency-store";
   String aggregationStreamAppId = "zipkin-aggregation";
 
-  String spansTopicName = "zipkin-spans";
-  String traceTopicName = "zipkin-trace";
-  String dependencyTopicName = "zipkin-dependency";
+  String partitionedSpansTopic = "zipkin-spans";
+  String aggregationSpansTopic = "zipkin-spans";
+  String aggregationTraceTopic = "zipkin-trace";
+  String aggregationDependencyTopic = "zipkin-dependency";
+  String storeSpansTopic = "zipkin-spans";
+  String storeDependencyTopic = "zipkin-dependency";
 
   KafkaStorageBuilder() {
     // Kafka Producer configuration
@@ -196,35 +197,72 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
   }
 
   /**
-   * Kafka topic name where incoming spans are stored.
+   * Kafka topic name where incoming partitioned spans are stored.
    * <p>
    * A Span is received from Collectors that contains all metadata and is partitioned by Trace Id.
    */
-  public KafkaStorageBuilder spansTopicName(String spansTopicName) {
-    if (spansTopicName == null) throw new NullPointerException("spansTopicName == null");
-    this.spansTopicName = spansTopicName;
+  public KafkaStorageBuilder partitionedSpansTopic(String partitionedSpansTopic) {
+    if (partitionedSpansTopic == null) {
+      throw new NullPointerException("partitionedSpansTopic == null");
+    }
+    this.partitionedSpansTopic = partitionedSpansTopic;
     return this;
   }
 
   /**
-   * Kafka topic name where incoming spans are stored.
-   * <p>
-   * A Span is received from Collectors that contains all metadata and is partitioned by Trace Id.
+   * Kafka topic name where partitioned spans are stored to be used on aggregation.
    */
-  public KafkaStorageBuilder tracesTopicName(String tracesTopicName) {
-    if (tracesTopicName == null) throw new NullPointerException("tracesTopicName == null");
-    this.traceTopicName = tracesTopicName;
+  public KafkaStorageBuilder aggregationSpansTopic(String aggregationSpansTopic) {
+    if (aggregationSpansTopic == null) {
+      throw new NullPointerException("aggregationSpansTopic == null");
+    }
+    this.aggregationSpansTopic = aggregationSpansTopic;
+    return this;
+  }
+
+  /**
+   * Kafka topic name where aggregated traces are stored.
+   * <p>
+   * Topic with key = traceId and value = list of Spans.
+   */
+  public KafkaStorageBuilder aggregationTraceTopic(String aggregationTraceTopic) {
+    if (aggregationTraceTopic == null) {
+      throw new NullPointerException("aggregationTraceTopic == null");
+    }
+    this.aggregationTraceTopic = aggregationTraceTopic;
+    return this;
+  }
+
+  /**
+   * Kafka topic name where dependencies changelog are stored.
+   * <p>
+   * Topic with key = parent-child pair and value = dependency link
+   */
+  public KafkaStorageBuilder aggregationDependencyTopic(String aggregationDependencyTopic) {
+    if (aggregationDependencyTopic == null) {
+      throw new NullPointerException("aggregationDependencyTopic == null");
+    }
+    this.aggregationDependencyTopic = aggregationDependencyTopic;
+    return this;
+  }
+
+  /**
+   * Kafka topic name where partitioned spans are stored to be used on aggregation.
+   */
+  public KafkaStorageBuilder storeSpansTopic(String storeSpansTopic) {
+    if (storeSpansTopic == null) throw new NullPointerException("storeSpansTopic == null");
+    this.storeSpansTopic = storeSpansTopic;
     return this;
   }
 
   /**
    * Kafka topic name where dependencies changelog are stored.
    */
-  public KafkaStorageBuilder dependenciesTopicName(String dependenciesTopicName) {
-    if (dependenciesTopicName == null) {
-      throw new NullPointerException("dependenciesTopicName == null");
+  public KafkaStorageBuilder storeDependencyTopic(String storeDependencyTopic) {
+    if (storeDependencyTopic == null) {
+      throw new NullPointerException("storeDependencyTopic == null");
     }
-    this.dependencyTopicName = dependenciesTopicName;
+    this.storeDependencyTopic = storeDependencyTopic;
     return this;
   }
 

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
@@ -62,8 +62,8 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
   String aggregationSpansTopic = "zipkin-spans";
   String aggregationTraceTopic = "zipkin-trace";
   String aggregationDependencyTopic = "zipkin-dependency";
-  String storeSpansTopic = "zipkin-spans";
-  String storeDependencyTopic = "zipkin-dependency";
+  String storageSpansTopic = "zipkin-spans";
+  String storageDependencyTopic = "zipkin-dependency";
 
   KafkaStorageBuilder() {
     // Kafka Producer configuration
@@ -249,20 +249,20 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
   /**
    * Kafka topic name where partitioned spans are stored to be used on aggregation.
    */
-  public KafkaStorageBuilder storeSpansTopic(String storeSpansTopic) {
-    if (storeSpansTopic == null) throw new NullPointerException("storeSpansTopic == null");
-    this.storeSpansTopic = storeSpansTopic;
+  public KafkaStorageBuilder storageSpansTopic(String storageSpansTopic) {
+    if (storageSpansTopic == null) throw new NullPointerException("storageSpansTopic == null");
+    this.storageSpansTopic = storageSpansTopic;
     return this;
   }
 
   /**
    * Kafka topic name where dependencies changelog are stored.
    */
-  public KafkaStorageBuilder storeDependencyTopic(String storeDependencyTopic) {
-    if (storeDependencyTopic == null) {
-      throw new NullPointerException("storeDependencyTopic == null");
+  public KafkaStorageBuilder storageDependencyTopic(String storageDependencyTopic) {
+    if (storageDependencyTopic == null) {
+      throw new NullPointerException("storageDependencyTopic == null");
     }
-    this.storeDependencyTopic = storeDependencyTopic;
+    this.storageDependencyTopic = storageDependencyTopic;
     return this;
   }
 

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStoreTopologySupplier.java
@@ -34,16 +34,18 @@ public final class DependencyStoreTopologySupplier implements Supplier<Topology>
   public static final String DEPENDENCIES_STORE_NAME = "zipkin-dependencies";
 
   // Kafka topics
-  final String dependencyTopicName;
+  final String dependencyTopic;
   // Configs
   final Duration dependencyTtl;
   final Duration dependencyWindowSize;
   // SerDes
   final DependencyLinkSerde dependencyLinkSerde;
 
-  public DependencyStoreTopologySupplier(String dependencyTopicName,
-      Duration dependencyTtl, Duration dependencyWindowSize) {
-    this.dependencyTopicName = dependencyTopicName;
+  public DependencyStoreTopologySupplier(
+      String dependencyTopic,
+      Duration dependencyTtl,
+      Duration dependencyWindowSize) {
+    this.dependencyTopic = dependencyTopic;
     this.dependencyTtl = dependencyTtl;
     this.dependencyWindowSize = dependencyWindowSize;
     dependencyLinkSerde = new DependencyLinkSerde();
@@ -65,7 +67,7 @@ public final class DependencyStoreTopologySupplier implements Supplier<Topology>
             dependencyLinkSerde
         ).withLoggingDisabled());
     // Consume dependency links stream
-    builder.stream(dependencyTopicName, Consumed.with(Serdes.String(), dependencyLinkSerde))
+    builder.stream(dependencyTopic, Consumed.with(Serdes.String(), dependencyLinkSerde))
         // Storage
         .process(() -> new Processor<String, DependencyLink>() {
           ProcessorContext context;

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
@@ -43,9 +43,7 @@ import zipkin2.storage.kafka.streams.serdes.SpansSerde;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-/**
- * Storage of Traces, Service names and Autocomplete Tags.
- */
+/** Storage of Traces, Service names and Autocomplete Tags. */
 public class TraceStoreTopologySupplier implements Supplier<Topology> {
   public static final String TRACES_STORE_NAME = "zipkin-traces";
   public static final String SPAN_IDS_BY_TS_STORE_NAME = "zipkin-traces-by-timestamp";
@@ -56,7 +54,7 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
   static final Logger LOG = LogManager.getLogger();
 
   // Kafka topics
-  final String spansTopicName;
+  final String spansTopic;
   // Limits
   final List<String> autoCompleteKeys;
   final Duration traceTtl;
@@ -69,9 +67,13 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
 
   final Counter brokenTracesTotal;
 
-  public TraceStoreTopologySupplier(String spansTopicName, List<String> autoCompleteKeys,
-      Duration traceTtl, Duration traceTtlCheckInterval, long minTracesStored) {
-    this.spansTopicName = spansTopicName;
+  public TraceStoreTopologySupplier(
+      String spansTopic,
+      List<String> autoCompleteKeys,
+      Duration traceTtl,
+      Duration traceTtlCheckInterval,
+      long minTracesStored) {
+    this.spansTopic = spansTopic;
     this.autoCompleteKeys = autoCompleteKeys;
     this.traceTtl = traceTtl;
     this.traceTtlCheckInterval = traceTtlCheckInterval;
@@ -123,7 +125,7 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
             namesSerde));
     // Traces stream
     KStream<String, List<Span>> spansStream = builder
-        .stream(spansTopicName, Consumed.with(Serdes.String(), spansSerde));
+        .stream(spansTopic, Consumed.with(Serdes.String(), spansSerde));
     // Store traces
     spansStream.process(() -> new Processor<String, List<Span>>() {
       // Actual traces store

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
@@ -29,9 +29,17 @@ class KafkaStorageBuilderTest {
     KafkaStorageBuilder builder = KafkaStorage.newBuilder();
     assertThat(builder.storageDir).isNotNull();
 
-    assertThatThrownBy(() -> builder.spansTopicName(null))
+    assertThatThrownBy(() -> builder.partitionedSpansTopic(null))
         .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.dependenciesTopicName(null))
+    assertThatThrownBy(() -> builder.aggregationSpansTopic(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.aggregationTraceTopic(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.aggregationDependencyTopic(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.storeSpansTopic(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.storeDependencyTopic(null))
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.storageDir(null))
         .isInstanceOf(NullPointerException.class);

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
@@ -37,9 +37,9 @@ class KafkaStorageBuilderTest {
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.aggregationDependencyTopic(null))
         .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.storeSpansTopic(null))
+    assertThatThrownBy(() -> builder.storageSpansTopic(null))
         .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.storeDependencyTopic(null))
+    assertThatThrownBy(() -> builder.storageDependencyTopic(null))
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.storageDir(null))
         .isInstanceOf(NullPointerException.class);

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
@@ -167,13 +167,13 @@ class KafkaStorageIT {
     // When: and stores running
     ServiceAndSpanNames serviceAndSpanNames = storage.serviceAndSpanNames();
     // When: been published
-    tracesProducer.send(new ProducerRecord<>(storage.storeSpansTopic, parent.traceId(), spans));
-    tracesProducer.send(new ProducerRecord<>(storage.storeSpansTopic, other.traceId(),
+    tracesProducer.send(new ProducerRecord<>(storage.storageSpansTopic, parent.traceId(), spans));
+    tracesProducer.send(new ProducerRecord<>(storage.storageSpansTopic, other.traceId(),
       Collections.singletonList(other)));
     tracesProducer.flush();
     // Then: stored
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.storeSpansTopic, 2, 10000);
+      consumerConfig, storage.storageSpansTopic, 2, 10000);
     // Then: services names are searchable
     await().atMost(100, TimeUnit.SECONDS).until(() -> {
       List<List<Span>> traces = storage.spanStore().getTraces(QueryRequest.newBuilder()
@@ -210,7 +210,7 @@ class KafkaStorageIT {
     //Given: two related dependency links
     // When: sent first one
     dependencyProducer.send(
-      new ProducerRecord<>(storage.storeDependencyTopic, "svc_a:svc_b",
+      new ProducerRecord<>(storage.storageDependencyTopic, "svc_a:svc_b",
         DependencyLink.newBuilder()
           .parent("svc_a")
           .child("svc_b")
@@ -219,7 +219,7 @@ class KafkaStorageIT {
           .build()));
     // When: and another one
     dependencyProducer.send(
-      new ProducerRecord<>(storage.storeDependencyTopic, "svc_a:svc_b",
+      new ProducerRecord<>(storage.storageDependencyTopic, "svc_a:svc_b",
         DependencyLink.newBuilder()
           .parent("svc_a")
           .child("svc_b")
@@ -229,7 +229,7 @@ class KafkaStorageIT {
     dependencyProducer.flush();
     // Then: stored in topic
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.storeDependencyTopic, 2, 10000);
+      consumerConfig, storage.storageDependencyTopic, 2, 10000);
     // Then:
     await().atMost(10, TimeUnit.SECONDS).until(() -> {
       List<DependencyLink> links = new ArrayList<>();

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
@@ -32,8 +32,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,8 +54,6 @@ import static org.awaitility.Awaitility.await;
 
 @Testcontainers
 class KafkaStorageIT {
-  static final Logger LOG = LogManager.getLogger();
-
   static final long TODAY = System.currentTimeMillis();
 
   // TODO: does this need to be confluent container? #45
@@ -89,9 +85,9 @@ class KafkaStorageIT {
       .build();
 
     Collection<NewTopic> newTopics = new ArrayList<>();
-    newTopics.add(new NewTopic(storage.spansTopicName, 1, (short) 1));
-    newTopics.add(new NewTopic(storage.traceTopicName, 1, (short) 1));
-    newTopics.add(new NewTopic(storage.dependencyTopicName, 1, (short) 1));
+    newTopics.add(new NewTopic(storage.aggregationSpansTopic, 1, (short) 1));
+    newTopics.add(new NewTopic(storage.aggregationTraceTopic, 1, (short) 1));
+    newTopics.add(new NewTopic(storage.aggregationDependencyTopic, 1, (short) 1));
     storage.getAdminClient().createTopics(newTopics).all().get();
 
     await().atMost(10, TimeUnit.SECONDS).until(() -> storage.check().ok());
@@ -131,7 +127,7 @@ class KafkaStorageIT {
     storage.getProducer().flush();
     // Then: they are partitioned
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.spansTopicName, 1, 10000);
+      consumerConfig, storage.partitionedSpansTopic, 1, 10000);
     // Given: some time for stream processes to kick in
     Thread.sleep(traceTimeout.toMillis() * 2);
     // Given: another span to move 'event time' forward
@@ -144,12 +140,12 @@ class KafkaStorageIT {
     storage.getProducer().flush();
     // Then: a trace is published
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.spansTopicName, 1, 1000);
+      consumerConfig, storage.aggregationSpansTopic, 1, 1000);
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.traceTopicName, 1, 30000);
+      consumerConfig, storage.aggregationTraceTopic, 1, 30000);
     // Then: and a dependency link created
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.dependencyTopicName, 1, 1000);
+      consumerConfig, storage.aggregationDependencyTopic, 1, 1000);
   }
 
   @Test void should_return_traces_query() throws Exception {
@@ -171,13 +167,13 @@ class KafkaStorageIT {
     // When: and stores running
     ServiceAndSpanNames serviceAndSpanNames = storage.serviceAndSpanNames();
     // When: been published
-    tracesProducer.send(new ProducerRecord<>(storage.spansTopicName, parent.traceId(), spans));
-    tracesProducer.send(new ProducerRecord<>(storage.spansTopicName, other.traceId(),
+    tracesProducer.send(new ProducerRecord<>(storage.storeSpansTopic, parent.traceId(), spans));
+    tracesProducer.send(new ProducerRecord<>(storage.storeSpansTopic, other.traceId(),
       Collections.singletonList(other)));
     tracesProducer.flush();
     // Then: stored
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.spansTopicName, 2, 10000);
+      consumerConfig, storage.storeSpansTopic, 2, 10000);
     // Then: services names are searchable
     await().atMost(100, TimeUnit.SECONDS).until(() -> {
       List<List<Span>> traces = storage.spanStore().getTraces(QueryRequest.newBuilder()
@@ -214,7 +210,7 @@ class KafkaStorageIT {
     //Given: two related dependency links
     // When: sent first one
     dependencyProducer.send(
-      new ProducerRecord<>(storage.dependencyTopicName, "svc_a:svc_b",
+      new ProducerRecord<>(storage.storeDependencyTopic, "svc_a:svc_b",
         DependencyLink.newBuilder()
           .parent("svc_a")
           .child("svc_b")
@@ -223,7 +219,7 @@ class KafkaStorageIT {
           .build()));
     // When: and another one
     dependencyProducer.send(
-      new ProducerRecord<>(storage.dependencyTopicName, "svc_a:svc_b",
+      new ProducerRecord<>(storage.storeDependencyTopic, "svc_a:svc_b",
         DependencyLink.newBuilder()
           .parent("svc_a")
           .child("svc_b")
@@ -233,7 +229,7 @@ class KafkaStorageIT {
     dependencyProducer.flush();
     // Then: stored in topic
     IntegrationTestUtils.waitUntilMinRecordsReceived(
-      consumerConfig, storage.dependencyTopicName, 2, 10000);
+      consumerConfig, storage.storeDependencyTopic, 2, 10000);
     // Then:
     await().atMost(10, TimeUnit.SECONDS).until(() -> {
       List<DependencyLink> links = new ArrayList<>();


### PR DESCRIPTION
We have 3 main components processing tracing data: span-consumer partitioning spans, aggregation turning spans into traces and dependency links, and store using spans (or potentially traces) and dependency links to support queries.

I'd like to propose to keep topics configs by component in order to support the following cases:
- Similar to #27, there are scenarios where we want to support query from aggregated traces and not partitioned spans.
- We might want to have some external processing between partitioned spans and spans used by store.

Fixes #27 