### PR TITLE
Fix memory leak on Dependency Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <armeria.version>0.94.0</armeria.version>
     <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
+    <kafka.version>2.3.1</kafka.version>
+
     <log4j.version>2.12.1</log4j.version>
     <junit-jupiter.version>5.5.2</junit-jupiter.version>
     <testcontainers.version>1.12.1</testcontainers.version>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -27,7 +27,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <kafka.version>2.3.0</kafka.version>
   </properties>
 
   <dependencies>
@@ -40,11 +39,23 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
       <version>${kafka.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${armeria.groupId}</groupId>

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
@@ -47,7 +47,7 @@ final class KafkaAutocompleteTags implements AutocompleteTags {
 
   @Override public Call<List<String>> getKeys() {
     if (traceSearchEnabled) {
-      return new GetTagKeysCall(storage.getTraceStoreStream(), httpBaseUrl);
+      return new GetTagKeysCall(storage.getTraceStorageStream(), httpBaseUrl);
     } else {
       return Call.emptyList();
     }
@@ -55,7 +55,7 @@ final class KafkaAutocompleteTags implements AutocompleteTags {
 
   @Override public Call<List<String>> getValues(String key) {
     if (traceSearchEnabled) {
-      return new GetTagValuesCall(storage.getTraceStoreStream(), httpBaseUrl, key);
+      return new GetTagValuesCall(storage.getTraceStorageStream(), httpBaseUrl, key);
     } else {
       return Call.emptyList();
     }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -74,7 +74,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Override public Call<List<List<Span>>> getTraces(QueryRequest request) {
     if (traceSearchEnabled) {
-      return new GetTracesCall(storage.getTraceStoreStream(), httpBaseUrl, request);
+      return new GetTracesCall(storage.getTraceStorageStream(), httpBaseUrl, request);
     } else {
       return Call.emptyList();
     }
@@ -83,7 +83,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
   @SuppressWarnings("deprecation")
   @Override public Call<List<Span>> getTrace(String traceId) {
     if (traceByIdQueryEnabled) {
-      return new GetTraceCall(storage.getTraceStoreStream(), httpBaseUrl,
+      return new GetTraceCall(storage.getTraceStorageStream(), httpBaseUrl,
           Span.normalizeTraceId(traceId));
     } else {
       return Call.emptyList();
@@ -98,7 +98,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
       }
 
       if (joiner.length() == 0) return Call.emptyList();
-      return new GetTraceManyCall(storage.getTraceStoreStream(), httpBaseUrl, joiner.toString());
+      return new GetTraceManyCall(storage.getTraceStorageStream(), httpBaseUrl, joiner.toString());
     } else {
       return Call.emptyList();
     }
@@ -106,7 +106,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Deprecated @Override public Call<List<String>> getServiceNames() {
     if (traceSearchEnabled) {
-      return new GetServiceNamesCall(storage.getTraceStoreStream(), httpBaseUrl);
+      return new GetServiceNamesCall(storage.getTraceStorageStream(), httpBaseUrl);
     } else {
       return Call.emptyList();
     }
@@ -114,7 +114,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Deprecated @Override public Call<List<String>> getSpanNames(String serviceName) {
     if (traceSearchEnabled) {
-      return new GetSpanNamesCall(storage.getTraceStoreStream(), serviceName, httpBaseUrl);
+      return new GetSpanNamesCall(storage.getTraceStorageStream(), serviceName, httpBaseUrl);
     } else {
       return Call.emptyList();
     }
@@ -122,7 +122,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Override public Call<List<String>> getRemoteServiceNames(String serviceName) {
     if (traceSearchEnabled) {
-      return new GetRemoteServiceNamesCall(storage.getTraceStoreStream(), serviceName, httpBaseUrl);
+      return new GetRemoteServiceNamesCall(storage.getTraceStorageStream(), serviceName, httpBaseUrl);
     } else {
       return Call.emptyList();
     }
@@ -130,7 +130,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Override public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
     if (dependencyQueryEnabled) {
-      return new GetDependenciesCall(storage.getDependencyStoreStream(), httpBaseUrl, endTs, lookback);
+      return new GetDependenciesCall(storage.getDependencyStorageStream(), httpBaseUrl, endTs, lookback);
     } else {
       return Call.emptyList();
     }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
@@ -26,8 +26,8 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.storage.AutocompleteTags;
@@ -54,7 +54,7 @@ import zipkin2.storage.kafka.streams.TraceStorageTopology;
 public class KafkaStorage extends StorageComponent {
   public static final String HTTP_PATH_PREFIX = "/storage/kafka";
 
-  static final Logger LOG = LogManager.getLogger();
+  static final Logger LOG = LoggerFactory.getLogger(KafkaStorage.class);
 
   public static KafkaStorageBuilder newBuilder() {
     return new KafkaStorageBuilder();
@@ -171,8 +171,8 @@ public class KafkaStorage extends StorageComponent {
 
   void checkResources() {
     getAggregationStream();
-    getTraceStoreStream();
-    getDependencyStoreStream();
+    getTraceStorageStream();
+    getDependencyStorageStream();
   }
 
   @Override public CheckResult check() {
@@ -184,12 +184,12 @@ public class KafkaStorage extends StorageComponent {
         return CheckResult.failed(
             new IllegalStateException("Aggregation stream not running. " + state));
       }
-      KafkaStreams.State traceStateStore = getTraceStoreStream().state();
+      KafkaStreams.State traceStateStore = getTraceStorageStream().state();
       if (!traceStateStore.isRunning()) {
         return CheckResult.failed(
             new IllegalStateException("Store stream not running. " + traceStateStore));
       }
-      KafkaStreams.State dependencyStateStore = getDependencyStoreStream().state();
+      KafkaStreams.State dependencyStateStore = getDependencyStorageStream().state();
       if (!dependencyStateStore.isRunning()) {
         return CheckResult.failed(
             new IllegalStateException("Store stream not running. " + dependencyStateStore));
@@ -253,7 +253,7 @@ public class KafkaStorage extends StorageComponent {
     return adminClient;
   }
 
-  KafkaStreams getTraceStoreStream() {
+  KafkaStreams getTraceStorageStream() {
     if (traceStoreStream == null) {
       synchronized (this) {
         if (traceStoreStream == null) {
@@ -271,7 +271,7 @@ public class KafkaStorage extends StorageComponent {
     return traceStoreStream;
   }
 
-  KafkaStreams getDependencyStoreStream() {
+  KafkaStreams getDependencyStorageStream() {
     if (dependencyStoreStream == null) {
       synchronized (this) {
         if (dependencyStoreStream == null) {

--- a/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreListCall.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreListCall.java
@@ -28,13 +28,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin2.Call;
 import zipkin2.Callback;
 
 public abstract class KafkaStoreListCall<V> extends Call.Base<List<V>> {
-  static final Logger LOG = LogManager.getLogger();
+  static final Logger LOG = LoggerFactory.getLogger(KafkaStoreListCall.class);
   static final ObjectMapper MAPPER = new ObjectMapper();
 
   final KafkaStreams kafkaStreams;

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
@@ -34,8 +34,8 @@ import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin2.Span;
 import zipkin2.storage.kafka.streams.serdes.NamesSerde;
 import zipkin2.storage.kafka.streams.serdes.SpanIdsSerde;
@@ -53,7 +53,8 @@ public class TraceStorageTopology implements Supplier<Topology> {
   public static final String SPAN_NAMES_STORE_NAME = "zipkin-span-names";
   public static final String REMOTE_SERVICE_NAMES_STORE_NAME = "zipkin-remote-service-names";
   public static final String AUTOCOMPLETE_TAGS_STORE_NAME = "zipkin-autocomplete-tags";
-  static final Logger LOG = LogManager.getLogger();
+
+  static final Logger LOG = LoggerFactory.getLogger(TraceStorageTopology.class);
 
   // Kafka topics
   final String spansTopic;


### PR DESCRIPTION
A few `KeyValueStoreIterator`s were not closed properly, leading to OOM exceptions. After upgrading to Kafka 2.3.1 I starting to get warning messages about this.

For reference, this is how much this affects under considerable load:
![image](https://user-images.githubusercontent.com/6180701/67957029-4c77f500-fbf5-11e9-9c4d-93e5b02c3c55.png)
