### PR TITLE
Adopt backward iteration (KIP-617) on Window Stores to be available on kafka-streams-2.7

### DIFF
--- a/module/pom.xml
+++ b/module/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.contrib.zipkin-storage-kafka</groupId>

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -33,15 +33,15 @@ import static zipkin2.storage.kafka.KafkaStorage.HTTP_PATH_PREFIX;
 class ZipkinKafkaStorageModule {
 
   @ConditionalOnMissingBean @Bean StorageComponent storage(
-      @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
-      @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys,
-      @Value("${server.port:9411}") int port,
-      ZipkinKafkaStorageProperties properties) {
+    @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
+    @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys,
+    @Value("${server.port:9411}") int port,
+    ZipkinKafkaStorageProperties properties) {
     return properties.toBuilder()
-        .searchEnabled(searchEnabled)
-        .autocompleteKeys(autocompleteKeys)
-        .serverPort(port)
-        .build();
+      .searchEnabled(searchEnabled)
+      .autocompleteKeys(autocompleteKeys)
+      .serverPort(port)
+      .build();
   }
 
   //TODO replace when Armeria supports Consumer<ServerBuilder> #61

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
@@ -44,8 +44,6 @@ class ZipkinKafkaStorageModule {
       .build();
   }
 
-  //TODO replace when Armeria supports Consumer<ServerBuilder> #61
-  //@Bean public Consumer<ServerBuilder> storageHttpService(StorageComponent storage) {
   @Bean public ArmeriaServerConfigurator storageHttpService(StorageComponent storage) {
     return sb -> sb.annotatedService(HTTP_PATH_PREFIX, ((KafkaStorage) storage).httpService());
   }

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -88,8 +88,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return spanPartitioning;
   }
 
-  public void setSpanPartitioning(
-    SpanPartitioningProperties spanPartitioning) {
+  public void setSpanPartitioning(SpanPartitioningProperties spanPartitioning) {
     this.spanPartitioning = spanPartitioning;
   }
 
@@ -97,8 +96,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return spanAggregation;
   }
 
-  public void setSpanAggregation(
-    SpanAggregationProperties spanAggregation) {
+  public void setSpanAggregation(SpanAggregationProperties spanAggregation) {
     this.spanAggregation = spanAggregation;
   }
 
@@ -106,8 +104,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return traceStorage;
   }
 
-  public void setTraceStorage(
-    TraceStorageProperties traceStorage) {
+  public void setTraceStorage(TraceStorageProperties traceStorage) {
     this.traceStorage = traceStorage;
   }
 
@@ -115,8 +112,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
     return dependencyStorage;
   }
 
-  public void setDependencyStorage(
-    DependencyStorageProperties dependencyStorage) {
+  public void setDependencyStorage(DependencyStorageProperties dependencyStorage) {
     this.dependencyStorage = dependencyStorage;
   }
 

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -89,7 +89,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setSpanPartitioning(
-      SpanPartitioningProperties spanPartitioning) {
+    SpanPartitioningProperties spanPartitioning) {
     this.spanPartitioning = spanPartitioning;
   }
 
@@ -98,7 +98,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setSpanAggregation(
-      SpanAggregationProperties spanAggregation) {
+    SpanAggregationProperties spanAggregation) {
     this.spanAggregation = spanAggregation;
   }
 
@@ -107,7 +107,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setTraceStorage(
-      TraceStorageProperties traceStorage) {
+    TraceStorageProperties traceStorage) {
     this.traceStorage = traceStorage;
   }
 
@@ -116,7 +116,7 @@ public class ZipkinKafkaStorageProperties implements Serializable {
   }
 
   public void setDependencyStorage(
-      DependencyStorageProperties dependencyStorage) {
+    DependencyStorageProperties dependencyStorage) {
     this.dependencyStorage = dependencyStorage;
   }
 

--- a/module/src/test/java/zipkin2/module/storage/kafka/Access.java
+++ b/module/src/test/java/zipkin2/module/storage/kafka/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,9 @@ package zipkin2.module.storage.kafka;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-/**  opens package access for testing */
+/**
+ * opens package access for testing
+ */
 public final class Access {
   public static void registerKafka(AnnotationConfigApplicationContext context) {
     context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinKafkaStorageModule.class);

--- a/module/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageModuleTest.java
+++ b/module/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -39,12 +39,12 @@ class ZipkinKafkaStorageModuleTest {
     context.refresh();
 
     assertThatThrownBy(() -> context.getBean(KafkaStorage.class))
-        .isInstanceOf(NoSuchBeanDefinitionException.class);
+      .isInstanceOf(NoSuchBeanDefinitionException.class);
   }
 
   @Test void providesStorageComponent_whenStorageTypeKafka() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka"
+      "zipkin.storage.type:kafka"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
@@ -54,174 +54,174 @@ class ZipkinKafkaStorageModuleTest {
 
   @Test void canOverridesProperty_bootstrapServers() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.bootstrap-servers:host1:19092"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.bootstrap-servers:host1:19092"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .producerConfig.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
-        .isEqualTo("host1:19092");
+      .producerConfig.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
+      .isEqualTo("host1:19092");
   }
 
   @Test void canOverridesProperty_adminConfigs() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.overrides.bootstrap.servers:host1:19092"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.overrides.bootstrap.servers:host1:19092"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .adminConfig.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG))
-        .isEqualTo("host1:19092");
+      .adminConfig.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG))
+      .isEqualTo("host1:19092");
   }
 
   @Test void canOverridesProperty_producerConfigs() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-partitioning.overrides.acks:1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-partitioning.overrides.acks:1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .producerConfig.get(ProducerConfig.ACKS_CONFIG))
-        .isEqualTo("1");
+      .producerConfig.get(ProducerConfig.ACKS_CONFIG))
+      .isEqualTo("1");
   }
 
   @Test void canOverridesProperty_aggregationStreamConfigs() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-aggregation.overrides.application.id:agg1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-aggregation.overrides.application.id:agg1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .aggregationStreamConfig.get(StreamsConfig.APPLICATION_ID_CONFIG))
-        .isEqualTo("agg1");
+      .aggregationStreamConfig.get(StreamsConfig.APPLICATION_ID_CONFIG))
+      .isEqualTo("agg1");
   }
 
   @Test void canOverridesProperty_traceStoreStreamConfigs() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.trace-storage.overrides.application.id:store1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.trace-storage.overrides.application.id:store1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .traceStoreStreamConfig.getProperty(StreamsConfig.APPLICATION_ID_CONFIG))
-        .isEqualTo("store1");
+      .traceStoreStreamConfig.getProperty(StreamsConfig.APPLICATION_ID_CONFIG))
+      .isEqualTo("store1");
   }
 
   @Test void canOverridesProperty_dependencyStoreStreamConfigs() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.dependency-storage.overrides.application.id:store1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.dependency-storage.overrides.application.id:store1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .dependencyStoreStreamConfig.getProperty(StreamsConfig.APPLICATION_ID_CONFIG))
-        .isEqualTo("store1");
+      .dependencyStoreStreamConfig.getProperty(StreamsConfig.APPLICATION_ID_CONFIG))
+      .isEqualTo("store1");
   }
 
   @Test void canOverridesProperty_storeDirectory() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.storage-dir:/zipkin/storage"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.storage-dir:/zipkin/storage"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class)
-        .traceStoreStreamConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG))
-        .startsWith("/zipkin/storage");
+      .traceStoreStreamConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG))
+      .startsWith("/zipkin/storage");
     assertThat(context.getBean(KafkaStorage.class)
-        .dependencyStoreStreamConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG))
-        .startsWith("/zipkin/storage");
+      .dependencyStoreStreamConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG))
+      .startsWith("/zipkin/storage");
   }
 
   @Test void canOverridesProperty_partitionedSpansTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-partitioning.spans-topic:zipkin-spans-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-partitioning.spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).partitioningSpansTopic)
-        .isEqualTo("zipkin-spans-1");
+      .isEqualTo("zipkin-spans-1");
   }
 
   @Test void canOverridesProperty_aggregationSpansTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-aggregation.spans-topic:zipkin-spans-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-aggregation.spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).aggregationSpansTopic).isEqualTo(
-        "zipkin-spans-1");
+      "zipkin-spans-1");
   }
 
   @Test void canOverridesProperty_aggregationTraceTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-aggregation.trace-topic:zipkin-traces-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-aggregation.trace-topic:zipkin-traces-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).aggregationTraceTopic)
-        .isEqualTo("zipkin-traces-1");
+      .isEqualTo("zipkin-traces-1");
   }
 
   @Test void canOverridesProperty_aggregationDependencyTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.span-aggregation.dependency-topic:zipkin-dependencies-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.span-aggregation.dependency-topic:zipkin-dependencies-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).aggregationDependencyTopic)
-        .isEqualTo("zipkin-dependencies-1");
+      .isEqualTo("zipkin-dependencies-1");
   }
 
   @Test void canOverridesProperty_storageSpansTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.trace-storage.spans-topic:zipkin-spans-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.trace-storage.spans-topic:zipkin-spans-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).storageSpansTopic)
-        .isEqualTo("zipkin-spans-1");
+      .isEqualTo("zipkin-spans-1");
   }
 
   @Test void canOverridesProperty_storageDependencyTopic() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.dependency-storage.dependency-topic:zipkin-dependencies-1"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.dependency-storage.dependency-topic:zipkin-dependencies-1"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();
 
     assertThat(context.getBean(KafkaStorage.class).storageDependencyTopic)
-        .isEqualTo("zipkin-dependencies-1");
+      .isEqualTo("zipkin-dependencies-1");
   }
 
   @Test void canOverridesProperty_hostname() {
     TestPropertyValues.of(
-        "zipkin.storage.type:kafka",
-        "zipkin.storage.kafka.hostname:other_host"
+      "zipkin.storage.type:kafka",
+      "zipkin.storage.kafka.hostname:other_host"
     ).applyTo(context);
     Access.registerKafka(context);
     context.refresh();

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.2.0</armeria.version>
 
-    <kafka.version>2.6.0</kafka.version>
+    <kafka.version>2.7.0</kafka.version>
 
     <junit-jupiter.version>5.7.0</junit-jupiter.version>
     <testcontainers.version>1.15.0</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.contrib.zipkin-storage-kafka</groupId>
@@ -70,7 +72,7 @@
     <assertj.version>3.18.1</assertj.version>
 
     <!-- override to set exclusions per-project -->
-    <errorprone.args />
+    <errorprone.args/>
     <errorprone.version>2.4.0</errorprone.version>
     <log4j.version>2.14.0</log4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019-2020 The OpenZipkin Authors
+    Copyright 2019-2021 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.contrib.zipkin-storage-kafka</groupId>

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -66,13 +66,13 @@ final class KafkaAutocompleteTags implements AutocompleteTags {
     final BiFunction<String, Integer, String> httpBaseUrl;
 
     GetTagKeysCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl) {
+      BiFunction<String, Integer, String> httpBaseUrl) {
       super(
-          traceStoreStream,
-          AUTOCOMPLETE_TAGS_STORE_NAME,
-          httpBaseUrl,
-          "/autocompleteTags",
-          AUTOCOMPLETE_TAGS_LIMIT);
+        traceStoreStream,
+        AUTOCOMPLETE_TAGS_STORE_NAME,
+        httpBaseUrl,
+        "/autocompleteTags",
+        AUTOCOMPLETE_TAGS_LIMIT);
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
     }
@@ -92,14 +92,14 @@ final class KafkaAutocompleteTags implements AutocompleteTags {
     final String tagKey;
 
     GetTagValuesCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl,
-        String tagKey) {
+      BiFunction<String, Integer, String> httpBaseUrl,
+      String tagKey) {
       super(
-          traceStoreStream,
-          AUTOCOMPLETE_TAGS_STORE_NAME,
-          httpBaseUrl,
-          "/autocompleteTags/" + tagKey,
-          tagKey);
+        traceStoreStream,
+        AUTOCOMPLETE_TAGS_STORE_NAME,
+        httpBaseUrl,
+        "/autocompleteTags/" + tagKey,
+        tagKey);
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
       this.tagKey = tagKey;

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -64,10 +64,10 @@ final class KafkaSpanConsumer implements SpanConsumer {
     final byte[] value;
 
     KafkaProducerCall(
-        Producer<String, byte[]> kafkaProducer,
-        String topic,
-        String key,
-        byte[] value
+      Producer<String, byte[]> kafkaProducer,
+      String topic,
+      String key,
+      byte[] value
     ) {
       this.kafkaProducer = kafkaProducer;
       this.topic = topic;
@@ -76,10 +76,10 @@ final class KafkaSpanConsumer implements SpanConsumer {
     }
 
     static Call<Void> create(
-        Producer<String, byte[]> producer,
-        String topic,
-        String key,
-        byte[] value
+      Producer<String, byte[]> producer,
+      String topic,
+      String key,
+      byte[] value
     ) {
       return new KafkaProducerCall(producer, topic, key, value);
     }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -49,7 +49,6 @@ import zipkin2.storage.kafka.streams.TraceStorageTopology;
 
 import static zipkin2.storage.kafka.streams.DependencyStorageTopology.DEPENDENCIES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.REMOTE_SERVICE_NAMES_STORE_NAME;
-import static zipkin2.storage.kafka.streams.TraceStorageTopology.SERVICE_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.TRACES_STORE_NAME;
 
@@ -144,7 +143,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
         BiFunction<String, Integer, String> httpBaseUrl) {
       super(
           traceStoreStream,
-          SERVICE_NAMES_STORE_NAME,
+          SPAN_NAMES_STORE_NAME,
           httpBaseUrl,
           "/serviceNames",
           SERVICE_NAMES_LIMIT);

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -53,9 +53,8 @@ import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_NAMES_STOR
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.TRACES_STORE_NAME;
 
 /**
- * Span store backed by Kafka Stream distributed state stores built by {@link
- * TraceStorageTopology} and {@link DependencyStorageTopology}, and made accessible by
- * {@link  KafkaStorageHttpService}.
+ * Span store backed by Kafka Stream distributed state stores built by {@link TraceStorageTopology}
+ * and {@link DependencyStorageTopology}, and made accessible by {@link  KafkaStorageHttpService}.
  */
 final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
   static final ObjectMapper MAPPER = new ObjectMapper();
@@ -82,7 +81,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
   @Override public Call<List<Span>> getTrace(String traceId) {
     if (traceByIdQueryEnabled) {
       return new GetTraceCall(storage.getTraceStorageStream(), httpBaseUrl,
-          Span.normalizeTraceId(traceId));
+        Span.normalizeTraceId(traceId));
     } else {
       return Call.emptyList();
     }
@@ -120,7 +119,8 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Override public Call<List<String>> getRemoteServiceNames(String serviceName) {
     if (traceSearchEnabled) {
-      return new GetRemoteServiceNamesCall(storage.getTraceStorageStream(), serviceName, httpBaseUrl);
+      return new GetRemoteServiceNamesCall(storage.getTraceStorageStream(), serviceName,
+        httpBaseUrl);
     } else {
       return Call.emptyList();
     }
@@ -128,7 +128,8 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
 
   @Override public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
     if (dependencyQueryEnabled) {
-      return new GetDependenciesCall(storage.getDependencyStorageStream(), httpBaseUrl, endTs, lookback);
+      return new GetDependenciesCall(storage.getDependencyStorageStream(), httpBaseUrl, endTs,
+        lookback);
     } else {
       return Call.emptyList();
     }
@@ -140,13 +141,13 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final BiFunction<String, Integer, String> httpBaseUrl;
 
     GetServiceNamesCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl) {
+      BiFunction<String, Integer, String> httpBaseUrl) {
       super(
-          traceStoreStream,
-          SPAN_NAMES_STORE_NAME,
-          httpBaseUrl,
-          "/serviceNames",
-          SERVICE_NAMES_LIMIT);
+        traceStoreStream,
+        SPAN_NAMES_STORE_NAME,
+        httpBaseUrl,
+        "/serviceNames",
+        SERVICE_NAMES_LIMIT);
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
     }
@@ -166,9 +167,9 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final BiFunction<String, Integer, String> httpBaseUrl;
 
     GetSpanNamesCall(KafkaStreams traceStoreStream, String serviceName,
-        BiFunction<String, Integer, String> httpBaseUrl) {
+      BiFunction<String, Integer, String> httpBaseUrl) {
       super(traceStoreStream, SPAN_NAMES_STORE_NAME, httpBaseUrl,
-          "/serviceNames/" + serviceName + "/spanNames", serviceName);
+        "/serviceNames/" + serviceName + "/spanNames", serviceName);
       this.traceStoreStream = traceStoreStream;
       this.serviceName = serviceName;
       this.httpBaseUrl = httpBaseUrl;
@@ -189,9 +190,9 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final BiFunction<String, Integer, String> httpBaseUrl;
 
     GetRemoteServiceNamesCall(KafkaStreams traceStoreStream, String serviceName,
-        BiFunction<String, Integer, String> httpBaseUrl) {
+      BiFunction<String, Integer, String> httpBaseUrl) {
       super(traceStoreStream, REMOTE_SERVICE_NAMES_STORE_NAME, httpBaseUrl,
-          "/serviceNames/" + serviceName + "/remoteServiceNames", serviceName);
+        "/serviceNames/" + serviceName + "/remoteServiceNames", serviceName);
       this.traceStoreStream = traceStoreStream;
       this.serviceName = serviceName;
       this.httpBaseUrl = httpBaseUrl;
@@ -212,25 +213,25 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final QueryRequest request;
 
     GetTracesCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl,
-        QueryRequest request) {
+      BiFunction<String, Integer, String> httpBaseUrl,
+      QueryRequest request) {
       super(
-          traceStoreStream,
-          TRACES_STORE_NAME,
-          httpBaseUrl,
-          ("/traces?"
-              + (request.serviceName() == null ? "" : "serviceName=" + request.serviceName() + "&")
-              + (request.remoteServiceName() == null ? ""
-              : "remoteServiceName=" + request.remoteServiceName() + "&")
-              + (request.spanName() == null ? "" : "spanName=" + request.spanName() + "&")
-              + (request.annotationQueryString() == null ? ""
-              : "annotationQuery=" + request.annotationQueryString() + "&")
-              + (request.minDuration() == null ? "" : "minDuration=" + request.minDuration() + "&")
-              + (request.maxDuration() == null ? "" : "maxDuration=" + request.maxDuration() + "&")
-              + ("endTs=" + request.endTs() + "&")
-              + ("lookback=" + request.lookback() + "&")
-              + ("limit=" + request.limit())),
-          request.limit());
+        traceStoreStream,
+        TRACES_STORE_NAME,
+        httpBaseUrl,
+        ("/traces?"
+          + (request.serviceName() == null ? "" : "serviceName=" + request.serviceName() + "&")
+          + (request.remoteServiceName() == null ? ""
+          : "remoteServiceName=" + request.remoteServiceName() + "&")
+          + (request.spanName() == null ? "" : "spanName=" + request.spanName() + "&")
+          + (request.annotationQueryString() == null ? ""
+          : "annotationQuery=" + request.annotationQueryString() + "&")
+          + (request.minDuration() == null ? "" : "minDuration=" + request.minDuration() + "&")
+          + (request.maxDuration() == null ? "" : "maxDuration=" + request.maxDuration() + "&")
+          + ("endTs=" + request.endTs() + "&")
+          + ("lookback=" + request.lookback() + "&")
+          + ("limit=" + request.limit())),
+        request.limit());
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
       this.request = request;
@@ -251,10 +252,10 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final String traceId;
 
     GetTraceCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl,
-        String traceId) {
+      BiFunction<String, Integer, String> httpBaseUrl,
+      String traceId) {
       super(traceStoreStream, TRACES_STORE_NAME, httpBaseUrl, String.format("/traces/%s", traceId),
-          traceId);
+        traceId);
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
       this.traceId = traceId;
@@ -277,8 +278,8 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final String traceIds;
 
     GetTraceManyCall(KafkaStreams traceStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl,
-        String traceIds) {
+      BiFunction<String, Integer, String> httpBaseUrl,
+      String traceIds) {
       super(traceStoreStream, TRACES_STORE_NAME, httpBaseUrl, "/traceMany?traceIds=" + traceIds);
       this.traceStoreStream = traceStoreStream;
       this.httpBaseUrl = httpBaseUrl;
@@ -299,7 +300,7 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
       Map<HostInfo, List<String>> traceIdsByHost = new LinkedHashMap<>();
       for (String traceId : traceIds.split(",", 1_000)) {
         KeyQueryMetadata metadata =
-            traceStoreStream.queryMetadataForKey(TRACES_STORE_NAME, traceId, STRING_SERIALIZER);
+          traceStoreStream.queryMetadataForKey(TRACES_STORE_NAME, traceId, STRING_SERIALIZER);
         List<String> collected = traceIdsByHost.get(metadata.activeHost());
         if (collected == null) collected = new ArrayList<>();
         collected.add(traceId);
@@ -307,21 +308,21 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
       }
       // Only calls to hosts that have traceIds are executed
       List<CompletableFuture<AggregatedHttpResponse>> responseFutures =
-          traceIdsByHost.entrySet()
-              .stream()
-              .map(entry -> httpClient(entry.getKey())
-                  .get("/traceMany?traceIds=" + String.join(",", entry.getValue())))
-              .map(HttpResponse::aggregate)
-              .collect(Collectors.toList());
+        traceIdsByHost.entrySet()
+          .stream()
+          .map(entry -> httpClient(entry.getKey())
+            .get("/traceMany?traceIds=" + String.join(",", entry.getValue())))
+          .map(HttpResponse::aggregate)
+          .collect(Collectors.toList());
       return CompletableFuture.allOf(responseFutures.toArray(new CompletableFuture[0]))
-          .thenApply(unused ->
-              responseFutures.stream()
-                  .map(s -> s.getNow(AggregatedHttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)))
-                  .map(this::content)
-                  .map(this::parseList)
-                  .flatMap(Collection::stream)
-                  .distinct()
-                  .collect(Collectors.toList()));
+        .thenApply(unused ->
+          responseFutures.stream()
+            .map(s -> s.getNow(AggregatedHttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)))
+            .map(this::content)
+            .map(this::parseList)
+            .flatMap(Collection::stream)
+            .distinct()
+            .collect(Collectors.toList()));
     }
   }
 
@@ -333,14 +334,14 @@ final class KafkaSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
     final long endTs, lookback;
 
     GetDependenciesCall(KafkaStreams dependencyStoreStream,
-        BiFunction<String, Integer, String> httpBaseUrl,
-        long endTs, long lookback) {
+      BiFunction<String, Integer, String> httpBaseUrl,
+      long endTs, long lookback) {
       super(
-          dependencyStoreStream,
-          DEPENDENCIES_STORE_NAME,
-          httpBaseUrl,
-          "/dependencies?endTs=" + endTs + "&lookback=" + lookback,
-          DEPENDENCIES_LIMIT);
+        dependencyStoreStream,
+        DEPENDENCIES_STORE_NAME,
+        httpBaseUrl,
+        "/dependencies?endTs=" + endTs + "&lookback=" + lookback,
+        DEPENDENCIES_LIMIT);
       this.dependencyStoreStream = dependencyStoreStream;
       this.httpBaseUrl = httpBaseUrl;
       this.endTs = endTs;

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
@@ -119,24 +119,24 @@ public class KafkaStorage extends StorageComponent {
     this.dependencyStoreStreamConfig = builder.dependencyStorage.streamConfig;
 
     aggregationTopology = new SpanAggregationTopology(
-        builder.spanAggregation.spansTopic,
-        builder.spanAggregation.traceTopic,
-        builder.spanAggregation.dependencyTopic,
-        builder.spanAggregation.traceTimeout,
-        builder.spanAggregation.enabled).get();
+      builder.spanAggregation.spansTopic,
+      builder.spanAggregation.traceTopic,
+      builder.spanAggregation.dependencyTopic,
+      builder.spanAggregation.traceTimeout,
+      builder.spanAggregation.enabled).get();
     traceStoreTopology = new TraceStorageTopology(
-        builder.traceStorage.spansTopic,
-        autocompleteKeys,
-        builder.traceStorage.traceTtl,
-        builder.traceStorage.traceTtlCheckInterval,
-        builder.traceStorage.minTracesStored,
-        builder.traceStorage.traceByIdQueryEnabled,
-        builder.traceStorage.traceSearchEnabled).get();
+      builder.traceStorage.spansTopic,
+      autocompleteKeys,
+      builder.traceStorage.traceTtl,
+      builder.traceStorage.traceTtlCheckInterval,
+      builder.traceStorage.minTracesStored,
+      builder.traceStorage.traceByIdQueryEnabled,
+      builder.traceStorage.traceSearchEnabled).get();
     dependencyStoreTopology = new DependencyStorageTopology(
-        builder.dependencyStorage.dependencyTopic,
-        builder.dependencyStorage.dependencyTtl,
-        builder.dependencyStorage.dependencyWindowSize,
-        builder.dependencyStorage.enabled).get();
+      builder.dependencyStorage.dependencyTopic,
+      builder.dependencyStorage.dependencyTtl,
+      builder.dependencyStorage.dependencyWindowSize,
+      builder.dependencyStorage.enabled).get();
   }
 
   @Override public SpanConsumer spanConsumer() {
@@ -181,17 +181,17 @@ public class KafkaStorage extends StorageComponent {
       KafkaStreams.State state = getAggregationStream().state();
       if (!state.isRunningOrRebalancing()) {
         return CheckResult.failed(
-            new IllegalStateException("Aggregation stream not running. " + state));
+          new IllegalStateException("Aggregation stream not running. " + state));
       }
       KafkaStreams.State traceStateStore = getTraceStorageStream().state();
       if (!traceStateStore.isRunningOrRebalancing()) {
         return CheckResult.failed(
-            new IllegalStateException("Store stream not running. " + traceStateStore));
+          new IllegalStateException("Store stream not running. " + traceStateStore));
       }
       KafkaStreams.State dependencyStateStore = getDependencyStorageStream().state();
       if (!dependencyStateStore.isRunningOrRebalancing()) {
         return CheckResult.failed(
-            new IllegalStateException("Store stream not running. " + dependencyStateStore));
+          new IllegalStateException("Store stream not running. " + dependencyStateStore));
       }
       return CheckResult.OK;
     } catch (Exception e) {
@@ -264,7 +264,7 @@ public class KafkaStorage extends StorageComponent {
         if (dependencyStoreStream == null) {
           try {
             dependencyStoreStream =
-                new KafkaStreams(dependencyStoreTopology, dependencyStoreStreamConfig);
+              new KafkaStreams(dependencyStoreTopology, dependencyStoreStreamConfig);
             dependencyStoreStream.start();
             LOG.info("Dependency storage topology:\n{}", dependencyStoreTopology.describe());
           } catch (Exception e) {
@@ -301,18 +301,18 @@ public class KafkaStorage extends StorageComponent {
 
   @Override public String toString() {
     return "KafkaStorage{" +
-        " bootstrapServers=" + adminConfig.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG) +
-        ", spanPartitioning{ enabled=" + partitioningEnabled +
-        ", spansTopic=" + partitioningSpansTopic + "}" +
-        ", spanAggregation{ enabled=" + aggregationEnabled +
-        ", spansTopic=" + aggregationSpansTopic +
-        ", traceTopic=" + aggregationTraceTopic +
-        ", dependencyTopic=" + aggregationDependencyTopic + "}" +
-        ", traceStore { traceByIdQueryEnabled=" + traceByIdQueryEnabled +
-        ", traceSearchEnabled=" + traceSearchEnabled +
-        ", spansTopic=" + storageSpansTopic + "}" +
-        ", dependencyStore { dependencyQueryEnabled=" + dependencyQueryEnabled +
-        ", dependencyTopic=" + storageDependencyTopic + "}" +
-        '}';
+      " bootstrapServers=" + adminConfig.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG) +
+      ", spanPartitioning{ enabled=" + partitioningEnabled +
+      ", spansTopic=" + partitioningSpansTopic + "}" +
+      ", spanAggregation{ enabled=" + aggregationEnabled +
+      ", spansTopic=" + aggregationSpansTopic +
+      ", traceTopic=" + aggregationTraceTopic +
+      ", dependencyTopic=" + aggregationDependencyTopic + "}" +
+      ", traceStore { traceByIdQueryEnabled=" + traceByIdQueryEnabled +
+      ", traceSearchEnabled=" + traceSearchEnabled +
+      ", spansTopic=" + storageSpansTopic + "}" +
+      ", dependencyStore { dependencyQueryEnabled=" + dependencyQueryEnabled +
+      ", dependencyTopic=" + storageDependencyTopic + "}" +
+      '}';
   }
 }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
@@ -37,7 +37,7 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
   String hostname = "localhost";
   int serverPort = 9411;
   BiFunction<String, Integer, String> httpBaseUrl =
-      (hostname, port) -> "http://" + hostname + ":" + port + HTTP_PATH_PREFIX;
+    (hostname, port) -> "http://" + hostname + ":" + port + HTTP_PATH_PREFIX;
 
   SpanPartitioningBuilder spanPartitioning = new SpanPartitioningBuilder();
   SpanAggregationBuilder spanAggregation = new SpanAggregationBuilder();
@@ -457,7 +457,8 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
       streamConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, StringSerde.class);
       streamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, ByteArraySerde.class);
       streamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "zipkin-dependency-storage");
-      streamConfig.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/zipkin-storage-kafka/dependency-storage");
+      streamConfig.put(StreamsConfig.STATE_DIR_CONFIG,
+        "/tmp/zipkin-storage-kafka/dependency-storage");
       streamConfig.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
       streamConfig.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:9411");
     }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -243,7 +243,7 @@ public final class KafkaStorageBuilder extends StorageComponent.Builder {
       streamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, ByteArraySerde.class);
       streamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "zipkin-aggregation");
       streamConfig.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/zipkin-storage-kafka/aggregation");
-      streamConfig.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+      streamConfig.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
     }
 
     /**

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageHttpService.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageHttpService.java
@@ -77,8 +77,8 @@ final class KafkaStorageHttpService {
 
   @Get("/dependencies")
   public AggregatedHttpResponse getDependencies(
-      @Param("endTs") long endTs,
-      @Param("lookback") long lookback
+    @Param("endTs") long endTs,
+    @Param("lookback") long lookback
   ) {
     try {
       if (!storage.dependencyQueryEnabled) return AggregatedHttpResponse.of(HttpStatus.NOT_FOUND);
@@ -95,9 +95,9 @@ final class KafkaStorageHttpService {
       List<DependencyLink> mergedLinks = DependencyLinker.merge(links);
       LOG.debug("Dependencies found from={}-to={}: {}", from, to, mergedLinks.size());
       return AggregatedHttpResponse.of(
-          HttpStatus.OK,
-          MediaType.JSON,
-          DependencyLinkBytesEncoder.JSON_V1.encodeList(mergedLinks));
+        HttpStatus.OK,
+        MediaType.JSON,
+        DependencyLinkBytesEncoder.JSON_V1.encodeList(mergedLinks));
     } catch (InvalidStateStoreException e) {
       LOG.debug("State store is not ready", e);
       return AggregatedHttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
@@ -204,26 +204,27 @@ final class KafkaStorageHttpService {
     @Param("minDuration") Optional<Long> minDuration,
     @Param("maxDuration") Optional<Long> maxDuration,
     @Param("endTs") Optional<Long> endTs,
-      @Default("86400000") @Param("lookback") Long lookback,
-      @Default("10") @Param("limit") int limit
+    @Default("86400000") @Param("lookback") Long lookback,
+    @Default("10") @Param("limit") int limit
   ) {
     try {
       if (!storage.traceSearchEnabled) return AggregatedHttpResponse.of(HttpStatus.NOT_FOUND);
       QueryRequest request =
-          QueryRequest.newBuilder()
-            .serviceName(serviceName.orElse(null))
-            .remoteServiceName(remoteServiceName.orElse(null))
-            .spanName(spanName.orElse(null))
-            .parseAnnotationQuery(annotationQuery.orElse(null))
-            .minDuration(minDuration.orElse(null))
-            .maxDuration(maxDuration.orElse(null))
-            .endTs(endTs.orElse(System.currentTimeMillis()))
-            .lookback(lookback)
-            .limit(limit)
-            .build();
+        QueryRequest.newBuilder()
+          .serviceName(serviceName.orElse(null))
+          .remoteServiceName(remoteServiceName.orElse(null))
+          .spanName(spanName.orElse(null))
+          .parseAnnotationQuery(annotationQuery.orElse(null))
+          .minDuration(minDuration.orElse(null))
+          .maxDuration(maxDuration.orElse(null))
+          .endTs(endTs.orElse(System.currentTimeMillis()))
+          .lookback(lookback)
+          .limit(limit)
+          .build();
       ReadOnlyWindowStore<String, List<Span>> tracesStore =
         storage.getTraceStorageStream().store(
-          StoreQueryParameters.fromNameAndType(TRACES_STORE_NAME, QueryableStoreTypes.windowStore()));
+          StoreQueryParameters.fromNameAndType(TRACES_STORE_NAME,
+            QueryableStoreTypes.windowStore()));
       List<List<Span>> traces = new ArrayList<>();
       Instant from = Instant.ofEpochMilli(request.endTs() - request.lookback());
       Instant to = Instant.ofEpochMilli(request.endTs());
@@ -303,8 +304,8 @@ final class KafkaStorageHttpService {
     try {
       if (!storage.traceSearchEnabled) return MAPPER.createArrayNode();
       ReadOnlyKeyValueStore<String, Set<String>> autocompleteTagsStore =
-          storage.getTraceStorageStream().store(AUTOCOMPLETE_TAGS_STORE_NAME,
-              QueryableStoreTypes.keyValueStore());
+        storage.getTraceStorageStream().store(AUTOCOMPLETE_TAGS_STORE_NAME,
+          QueryableStoreTypes.keyValueStore());
       ArrayNode array = MAPPER.createArrayNode();
       try (KeyValueIterator<String, Set<String>> all = autocompleteTagsStore.all()) {
         all.forEachRemaining(keyValue -> array.add(keyValue.key));
@@ -320,7 +321,7 @@ final class KafkaStorageHttpService {
   @ProducesJson
   public KafkaStreamsMetadata getInstancesByStore(@Param("store_name") String storeName) {
     Collection<StreamsMetadata> metadata =
-        storage.getTraceStorageStream().allMetadataForStore(storeName);
+      storage.getTraceStorageStream().allMetadataForStore(storeName);
     metadata.addAll(storage.getDependencyStorageStream().allMetadataForStore(storeName));
     return KafkaStreamsMetadata.create(metadata);
   }

--- a/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreScatterGatherListCall.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreScatterGatherListCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -35,10 +35,10 @@ public abstract class KafkaStoreScatterGatherListCall<V> extends KafkaStoreListC
 
   /**
    * @param kafkaStreams Kafka Streams instance where storeName is located.
-   * @param storeName Store name which will be queried on all instances.
-   * @param httpBaseUrl Base URL composed by protocol, hostname and port.
-   * @param httpPath Http path to query other instances.
-   * @param limit Maximum number of results when collecting results from all instances.
+   * @param storeName    Store name which will be queried on all instances.
+   * @param httpBaseUrl  Base URL composed by protocol, hostname and port.
+   * @param httpPath     Http path to query other instances.
+   * @param limit        Maximum number of results when collecting results from all instances.
    */
   protected KafkaStoreScatterGatherListCall(
     KafkaStreams kafkaStreams,

--- a/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreSingleKeyListCall.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreSingleKeyListCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.state.StreamsMetadata;
+import org.apache.kafka.streams.KeyQueryMetadata;
 
 /**
  * Search for store by key and get values.
@@ -43,8 +43,8 @@ public abstract class KafkaStoreSingleKeyListCall<V> extends KafkaStoreListCall<
   }
 
   @Override protected CompletableFuture<List<V>> listFuture() {
-    StreamsMetadata metadata = kafkaStreams.metadataForKey(storeName, key, STRING_SERIALIZER);
-    WebClient httpClient = httpClient(metadata.hostInfo());
+    KeyQueryMetadata metadata = kafkaStreams.queryMetadataForKey(storeName, key, STRING_SERIALIZER);
+    WebClient httpClient = httpClient(metadata.activeHost());
     return httpClient.get(httpPath)
       .aggregate()
       .thenApply(response -> {

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
@@ -46,10 +46,10 @@ public final class DependencyStorageTopology implements Supplier<Topology> {
   final DependencyLinkSerde dependencyLinkSerde;
 
   public DependencyStorageTopology(
-      String dependencyTopic,
-      Duration dependencyTtl,
-      Duration dependencyWindowSize,
-      boolean dependencyQueryEnabled
+    String dependencyTopic,
+    Duration dependencyTtl,
+    Duration dependencyWindowSize,
+    boolean dependencyQueryEnabled
   ) {
     this.dependencyTopic = dependencyTopic;
     this.dependencyTtl = dependencyTtl;
@@ -63,55 +63,55 @@ public final class DependencyStorageTopology implements Supplier<Topology> {
     if (dependencyQueryEnabled) {
       // Dependency links window store
       builder.addStateStore(
-          // Disabling logging to avoid long starting times
-          Stores.windowStoreBuilder(
-              Stores.persistentWindowStore(
-                  DEPENDENCIES_STORE_NAME,
-                  dependencyTtl,
-                  dependencyWindowSize,
-                  false),
-              Serdes.String(),
-              dependencyLinkSerde
-          ).withLoggingDisabled());
+        // Disabling logging to avoid long starting times
+        Stores.windowStoreBuilder(
+          Stores.persistentWindowStore(
+            DEPENDENCIES_STORE_NAME,
+            dependencyTtl,
+            dependencyWindowSize,
+            false),
+          Serdes.String(),
+          dependencyLinkSerde
+        ).withLoggingDisabled());
       // Consume dependency links stream
       builder.stream(dependencyTopic, Consumed.with(Serdes.String(), dependencyLinkSerde))
-          // Storage
-          .process(() -> new Processor<String, DependencyLink>() {
-            ProcessorContext context;
-            WindowStore<String, DependencyLink> dependenciesStore;
+        // Storage
+        .process(() -> new Processor<String, DependencyLink>() {
+          ProcessorContext context;
+          WindowStore<String, DependencyLink> dependenciesStore;
 
-            @Override public void init(ProcessorContext context) {
-              this.context = context;
-              dependenciesStore = context.getStateStore(DEPENDENCIES_STORE_NAME);
-            }
+          @Override public void init(ProcessorContext context) {
+            this.context = context;
+            dependenciesStore = context.getStateStore(DEPENDENCIES_STORE_NAME);
+          }
 
-            @Override public void process(String linkKey, DependencyLink link) {
-              // Event time
-              Instant now = Instant.ofEpochMilli(context.timestamp());
-              Instant from = now.minus(dependencyWindowSize);
-              try (WindowStoreIterator<DependencyLink> currentLinkWindow =
-                  dependenciesStore.fetch(linkKey, from, now)) {
-                // Get latest window. Only two are possible.
-                KeyValue<Long, DependencyLink> windowAndValue = null;
-                if (currentLinkWindow.hasNext()) windowAndValue = currentLinkWindow.next();
-                if (currentLinkWindow.hasNext()) windowAndValue = currentLinkWindow.next();
-                // Persist dependency link per window
-                if (windowAndValue != null) {
-                  DependencyLink currentLink = windowAndValue.value;
-                  DependencyLink aggregated = currentLink.toBuilder()
-                      .callCount(currentLink.callCount() + link.callCount())
-                      .errorCount(currentLink.errorCount() + link.errorCount())
-                      .build();
-                  dependenciesStore.put(linkKey, aggregated, windowAndValue.key);
-                } else {
-                  dependenciesStore.put(linkKey, link, now.toEpochMilli());
-                }
+          @Override public void process(String linkKey, DependencyLink link) {
+            // Event time
+            Instant now = Instant.ofEpochMilli(context.timestamp());
+            Instant from = now.minus(dependencyWindowSize);
+            try (WindowStoreIterator<DependencyLink> currentLinkWindow =
+                   dependenciesStore.fetch(linkKey, from, now)) {
+              // Get latest window. Only two are possible.
+              KeyValue<Long, DependencyLink> windowAndValue = null;
+              if (currentLinkWindow.hasNext()) windowAndValue = currentLinkWindow.next();
+              if (currentLinkWindow.hasNext()) windowAndValue = currentLinkWindow.next();
+              // Persist dependency link per window
+              if (windowAndValue != null) {
+                DependencyLink currentLink = windowAndValue.value;
+                DependencyLink aggregated = currentLink.toBuilder()
+                  .callCount(currentLink.callCount() + link.callCount())
+                  .errorCount(currentLink.errorCount() + link.errorCount())
+                  .build();
+                dependenciesStore.put(linkKey, aggregated, windowAndValue.key);
+              } else {
+                dependenciesStore.put(linkKey, link, now.toEpochMilli());
               }
             }
+          }
 
-            @Override public void close() {
-            }
-          }, DEPENDENCIES_STORE_NAME);
+          @Override public void close() {
+          }
+        }, DEPENDENCIES_STORE_NAME);
     }
     return builder.build();
   }

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
@@ -80,12 +80,9 @@ public final class DependencyStorageTopology implements Supplier<Topology> {
             ProcessorContext context;
             WindowStore<String, DependencyLink> dependenciesStore;
 
-            @SuppressWarnings("unchecked")
             @Override public void init(ProcessorContext context) {
               this.context = context;
-              dependenciesStore =
-                  (WindowStore<String, DependencyLink>) context.getStateStore(
-                      DEPENDENCIES_STORE_NAME);
+              dependenciesStore = context.getStateStore(DEPENDENCIES_STORE_NAME);
             }
 
             @Override public void process(String linkKey, DependencyLink link) {

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ import static zipkin2.storage.kafka.streams.serdes.DependencyLinkSerde.linkKey;
 /** Processing of spans partitioned by trace Id, into traces and dependency links. */
 public final class SpanAggregationTopology implements Supplier<Topology> {
   static final String TRACE_AGGREGATION_STORE = "trace-aggregation";
+  static final Duration TRACE_AGGREGATION_RETENTION = Duration.ofDays(1);
   // Kafka topics
   final String spansTopic;
   final String traceTopic;
@@ -83,8 +84,9 @@ public final class SpanAggregationTopology implements Supplier<Topology> {
               .aggregate(ArrayList::new, aggregateSpans(), joinAggregates(),
                   Materialized
                       .<String, List<Span>>as(
-                          Stores.persistentSessionStore(TRACE_AGGREGATION_STORE,
-                              Duration.ofDays(1)))
+                          Stores.persistentSessionStore(
+                              TRACE_AGGREGATION_STORE,
+                              TRACE_AGGREGATION_RETENTION))
                       .withKeySerde(Serdes.String())
                       .withValueSerde(spansSerde)
                       .withLoggingDisabled()

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
@@ -40,7 +40,9 @@ import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.unbounded
 import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
 import static zipkin2.storage.kafka.streams.serdes.DependencyLinkSerde.linkKey;
 
-/** Processing of spans partitioned by trace Id, into traces and dependency links. */
+/**
+ * Processing of spans partitioned by trace Id, into traces and dependency links.
+ */
 public final class SpanAggregationTopology implements Supplier<Topology> {
   static final String TRACE_AGGREGATION_STORE = "trace-aggregation";
   static final Duration TRACE_AGGREGATION_RETENTION = Duration.ofDays(1);
@@ -57,11 +59,11 @@ public final class SpanAggregationTopology implements Supplier<Topology> {
   final DependencyLinkSerde dependencyLinkSerde;
 
   public SpanAggregationTopology(
-      String spansTopic,
-      String traceTopic,
-      String dependencyTopic,
-      Duration traceTimeout,
-      boolean aggregationEnabled
+    String spansTopic,
+    String traceTopic,
+    String dependencyTopic,
+    Duration traceTimeout,
+    boolean aggregationEnabled
   ) {
     this.spansTopic = spansTopic;
     this.traceTopic = traceTopic;
@@ -77,30 +79,30 @@ public final class SpanAggregationTopology implements Supplier<Topology> {
     if (aggregationEnabled) {
       // Aggregate Spans to Traces
       KStream<String, List<Span>> tracesStream =
-          builder.stream(spansTopic, Consumed.with(Serdes.String(), spansSerde))
-              .groupByKey()
-              // how long to wait for another span
-              .windowedBy(SessionWindows.with(traceTimeout).grace(Duration.ZERO))
-              .aggregate(ArrayList::new, aggregateSpans(), joinAggregates(),
-                  Materialized
-                      .<String, List<Span>>as(
-                          Stores.persistentSessionStore(
-                              TRACE_AGGREGATION_STORE,
-                              TRACE_AGGREGATION_RETENTION))
-                      .withKeySerde(Serdes.String())
-                      .withValueSerde(spansSerde)
-                      .withLoggingDisabled()
-                      .withCachingEnabled())
-              // hold until a new record tells that a window is closed and we can process it further
-              .suppress(untilWindowCloses(unbounded()))
-              .toStream()
-              .selectKey((windowed, spans) -> windowed.key());
+        builder.stream(spansTopic, Consumed.with(Serdes.String(), spansSerde))
+          .groupByKey()
+          // how long to wait for another span
+          .windowedBy(SessionWindows.with(traceTimeout).grace(Duration.ZERO))
+          .aggregate(ArrayList::new, aggregateSpans(), joinAggregates(),
+            Materialized
+              .<String, List<Span>>as(
+                Stores.persistentSessionStore(
+                  TRACE_AGGREGATION_STORE,
+                  TRACE_AGGREGATION_RETENTION))
+              .withKeySerde(Serdes.String())
+              .withValueSerde(spansSerde)
+              .withLoggingDisabled()
+              .withCachingEnabled())
+          // hold until a new record tells that a window is closed and we can process it further
+          .suppress(untilWindowCloses(unbounded()))
+          .toStream()
+          .selectKey((windowed, spans) -> windowed.key());
       // Downstream to traces topic
       tracesStream.to(traceTopic, Produced.with(Serdes.String(), spansSerde));
       // Map to dependency links
       tracesStream.flatMapValues(spansToDependencyLinks())
-          .selectKey((key, value) -> linkKey(value))
-          .to(dependencyTopic, Produced.with(Serdes.String(), dependencyLinkSerde));
+        .selectKey((key, value) -> linkKey(value))
+        .to(dependencyTopic, Produced.with(Serdes.String(), dependencyLinkSerde));
     }
     return builder.build();
   }

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -121,12 +121,9 @@ public class TraceStorageTopology implements Supplier<Topology> {
         // timestamp index for trace IDs
         KeyValueStore<Long, Set<String>> spanIdsByTsStore;
 
-        @SuppressWarnings("unchecked")
         @Override public void init(ProcessorContext context) {
-          tracesStore =
-              (KeyValueStore<String, List<Span>>) context.getStateStore(TRACES_STORE_NAME);
-          spanIdsByTsStore =
-              (KeyValueStore<Long, Set<String>>) context.getStateStore(SPAN_IDS_BY_TS_STORE_NAME);
+          tracesStore = context.getStateStore(TRACES_STORE_NAME);
+          spanIdsByTsStore = context.getStateStore(SPAN_IDS_BY_TS_STORE_NAME);
           // Retention scheduling
           context.schedule(
               traceTtlCheckInterval,
@@ -210,18 +207,11 @@ public class TraceStorageTopology implements Supplier<Topology> {
               KeyValueStore<String, Set<String>> remoteServiceNamesStore;
               KeyValueStore<String, Set<String>> autocompleteTagsStore;
 
-              @SuppressWarnings("unchecked")
               @Override public void init(ProcessorContext context) {
-                serviceNameStore =
-                    (KeyValueStore<String, String>) context.getStateStore(SERVICE_NAMES_STORE_NAME);
-                spanNamesStore =
-                    (KeyValueStore<String, Set<String>>) context.getStateStore(SPAN_NAMES_STORE_NAME);
-                remoteServiceNamesStore =
-                    (KeyValueStore<String, Set<String>>) context.getStateStore(
-                        REMOTE_SERVICE_NAMES_STORE_NAME);
-                autocompleteTagsStore =
-                    (KeyValueStore<String, Set<String>>) context.getStateStore(
-                        AUTOCOMPLETE_TAGS_STORE_NAME);
+                serviceNameStore = context.getStateStore(SERVICE_NAMES_STORE_NAME);
+                spanNamesStore = context.getStateStore(SPAN_NAMES_STORE_NAME);
+                remoteServiceNamesStore = context.getStateStore(REMOTE_SERVICE_NAMES_STORE_NAME);
+                autocompleteTagsStore = context.getStateStore(AUTOCOMPLETE_TAGS_STORE_NAME);
               }
 
               @Override

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
@@ -17,31 +17,26 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.PunctuationType;
-import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.Stores;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.kafka.streams.state.*;
 import zipkin2.Span;
 import zipkin2.storage.kafka.streams.serdes.NamesSerde;
 import zipkin2.storage.kafka.streams.serdes.SpanIdsSerde;
 import zipkin2.storage.kafka.streams.serdes.SpansSerde;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 /**
  * Storage of Traces, Service names and Autocomplete Tags.
@@ -49,12 +44,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class TraceStorageTopology implements Supplier<Topology> {
   public static final String TRACES_STORE_NAME = "zipkin-traces";
   public static final String SPAN_IDS_BY_TS_STORE_NAME = "zipkin-traces-by-timestamp";
-  public static final String SERVICE_NAMES_STORE_NAME = "zipkin-service-names";
   public static final String SPAN_NAMES_STORE_NAME = "zipkin-span-names";
   public static final String REMOTE_SERVICE_NAMES_STORE_NAME = "zipkin-remote-service-names";
   public static final String AUTOCOMPLETE_TAGS_STORE_NAME = "zipkin-autocomplete-tags";
-
-  static final Logger LOG = LoggerFactory.getLogger(TraceStorageTopology.class);
 
   // Kafka topics
   final String spansTopic;
@@ -99,141 +91,117 @@ public class TraceStorageTopology implements Supplier<Topology> {
     StreamsBuilder builder = new StreamsBuilder();
     if (traceSearchEnabled || traceByIdQueryEnabled) {
       builder
-          // Logging disabled to avoid long starting times, with logging disabled to process incoming
-          // spans since last restart
-          .addStateStore(Stores.keyValueStoreBuilder(
-              Stores.persistentKeyValueStore(TRACES_STORE_NAME),
-              Serdes.String(),
-              spansSerde).withLoggingDisabled())
-          // Disabling logging to avoid long starting times, with logging disabled to process incoming
-          // spans since last restart
-          .addStateStore(Stores.keyValueStoreBuilder(
-              Stores.persistentKeyValueStore(SPAN_IDS_BY_TS_STORE_NAME),
-              Serdes.Long(),
-              spanIdsSerde).withLoggingDisabled());
+        // Logging disabled to avoid long starting times, with logging disabled to process incoming
+        // spans since last restart
+        .addStateStore(Stores.windowStoreBuilder(
+          Stores.persistentWindowStore(TRACES_STORE_NAME, Duration.ofDays(1), Duration.ofHours(1), false),
+          Serdes.String(),
+          spansSerde).withLoggingDisabled());
       // Traces stream
       KStream<String, List<Span>> spansStream = builder
           .stream(spansTopic, Consumed.with(Serdes.String(), spansSerde));
       // Store traces
       spansStream.process(() -> new Processor<String, List<Span>>() {
         // Actual traces store
-        KeyValueStore<String, List<Span>> tracesStore;
-        // timestamp index for trace IDs
-        KeyValueStore<Long, Set<String>> spanIdsByTsStore;
+        WindowStore<String, List<Span>> tracesStore;
 
         @Override public void init(ProcessorContext context) {
           tracesStore = context.getStateStore(TRACES_STORE_NAME);
-          spanIdsByTsStore = context.getStateStore(SPAN_IDS_BY_TS_STORE_NAME);
-          // Retention scheduling
-          context.schedule(
-              traceTtlCheckInterval,
-              PunctuationType.STREAM_TIME,
-              timestamp -> {
-                if (traceTtl.toMillis() > 0 &&
-                    tracesStore.approximateNumEntries() > minTracesStored) {
-                  // query traceIds active during period
-                  long from = 0L;
-                  long to = timestamp - traceTtl.toMillis();
-                  try (final KeyValueIterator<Long, Set<String>> range =
-                           spanIdsByTsStore.range(from, MILLISECONDS.toMicros(to))) {
-                    range.forEachRemaining(record -> {
-                      spanIdsByTsStore.delete(record.key); // clean timestamp index
-                      for (String traceId : record.value) {
-                        tracesStore.delete(traceId); // clean traces store
-                      }
-                    });
-                    LOG.debug(
-                        "Traces deletion emitted at {}, approx. number of traces stored {}",
-                        Instant.ofEpochMilli(to).atZone(ZoneId.systemDefault()),
-                        tracesStore.approximateNumEntries());
-                  }
-                }
-              });
         }
 
         @Override public void process(String traceId, List<Span> spans) {
           if (!spans.isEmpty()) {
             // Persist traces
-            List<Span> currentSpans = tracesStore.get(traceId);
-            if (currentSpans == null) {
-              currentSpans = new ArrayList<>();
-            } else {
-              brokenTracesTotal.increment();
+            final Instant now = Instant.now();
+            try (WindowStoreIterator<List<Span>> iterator =
+                   tracesStore.backwardFetch(traceId, now.minusMillis(Duration.ofDays(1).toMillis()), now)) {
+              if (iterator.hasNext()) {
+                KeyValue<Long, List<Span>> current = iterator.next();
+                current.value.addAll(spans);
+                tracesStore.put(traceId, current.value, current.key);
+              } else {
+                long timestamp = MICROSECONDS.toMillis(spans.get(0).timestamp());
+                tracesStore.put(traceId, spans, timestamp);
+              }
             }
-            currentSpans.addAll(spans);
-            tracesStore.put(traceId, currentSpans);
-            // Persist timestamp indexed span ids
-            long timestamp = spans.get(0).timestamp();
-            Set<String> currentSpanIds = spanIdsByTsStore.get(timestamp);
-            if (currentSpanIds == null) currentSpanIds = new LinkedHashSet<>();
-            currentSpanIds.add(traceId);
-            spanIdsByTsStore.put(timestamp, currentSpanIds);
           }
         }
 
-        @Override public void close() {
+        @Override
+        public void close() {
         }
-      }, TRACES_STORE_NAME, SPAN_IDS_BY_TS_STORE_NAME);
+      }, TRACES_STORE_NAME);
       if (traceSearchEnabled) {
         builder
-            // In-memory as service names are bounded, with logging enabled to build state
-            // with all values collected
-            .addStateStore(Stores.keyValueStoreBuilder(
-                Stores.inMemoryKeyValueStore(SERVICE_NAMES_STORE_NAME),
-                Serdes.String(),
-                Serdes.String()))
             // In-memory as span names are bounded, with logging enabled to build state
             // with all values collected
-            .addStateStore(Stores.keyValueStoreBuilder(
-                Stores.inMemoryKeyValueStore(SPAN_NAMES_STORE_NAME),
+            .addStateStore(Stores.windowStoreBuilder(
+                Stores.inMemoryWindowStore(SPAN_NAMES_STORE_NAME, Duration.ofDays(7), Duration.ofDays(1), false),
                 Serdes.String(),
                 namesSerde))
             // In-memory as remote-service names are bounded, with logging enabled to build state
             // with all values collected
-            .addStateStore(Stores.keyValueStoreBuilder(
-                Stores.inMemoryKeyValueStore(REMOTE_SERVICE_NAMES_STORE_NAME),
+            .addStateStore(Stores.windowStoreBuilder(
+              Stores.inMemoryWindowStore(REMOTE_SERVICE_NAMES_STORE_NAME, Duration.ofDays(7), Duration.ofDays(1), false),
                 Serdes.String(),
                 namesSerde))
             // Persistent as values could be unbounded, but with logging enabled to build state
             // with all values collected
-            .addStateStore(Stores.keyValueStoreBuilder(
-                Stores.persistentKeyValueStore(AUTOCOMPLETE_TAGS_STORE_NAME),
+            .addStateStore(Stores.windowStoreBuilder(
+                Stores.persistentWindowStore(AUTOCOMPLETE_TAGS_STORE_NAME, Duration.ofDays(7), Duration.ofDays(1), false),
                 Serdes.String(),
                 namesSerde));
         // Store service, span and remote service names
         spansStream.process(() -> new Processor<String, List<Span>>() {
-              KeyValueStore<String, String> serviceNameStore;
-              KeyValueStore<String, Set<String>> spanNamesStore;
-              KeyValueStore<String, Set<String>> remoteServiceNamesStore;
-              KeyValueStore<String, Set<String>> autocompleteTagsStore;
+            WindowStore<String, Set<String>> spanNamesStore;
+            WindowStore<String, Set<String>> remoteServiceNamesStore;
+            WindowStore<String, Set<String>> autocompleteTagsStore;
 
-              @Override public void init(ProcessorContext context) {
-                serviceNameStore = context.getStateStore(SERVICE_NAMES_STORE_NAME);
-                spanNamesStore = context.getStateStore(SPAN_NAMES_STORE_NAME);
-                remoteServiceNamesStore = context.getStateStore(REMOTE_SERVICE_NAMES_STORE_NAME);
-                autocompleteTagsStore = context.getStateStore(AUTOCOMPLETE_TAGS_STORE_NAME);
-              }
+            @Override
+            public void init(ProcessorContext context) {
+              spanNamesStore = context.getStateStore(SPAN_NAMES_STORE_NAME);
+              remoteServiceNamesStore = context.getStateStore(REMOTE_SERVICE_NAMES_STORE_NAME);
+              autocompleteTagsStore = context.getStateStore(AUTOCOMPLETE_TAGS_STORE_NAME);
+            }
 
               @Override
               public void process(String traceId, List<Span> spans) {
+                Instant now = Instant.now();
                 for (Span span : spans) {
+                  final long timestamp = MICROSECONDS.toMillis(span.timestamp());
                   if (span.localServiceName() != null) { // if service name
-                    serviceNameStore.putIfAbsent(span.localServiceName(), span.localServiceName());
                     if (span.name() != null) { // store span names
-                      Set<String> spanNames = spanNamesStore.get(span.localServiceName());
-                      if (spanNames == null) spanNames = new LinkedHashSet<>();
-                      if (!spanNames.contains(span.name())) {
-                        spanNames.add(span.name());
-                        spanNamesStore.put(span.localServiceName(), spanNames);
+                      try (WindowStoreIterator<Set<String>> iterator =
+                             spanNamesStore.backwardFetch(span.localServiceName(), now.minusMillis(Duration.ofDays(7).toMillis()), now)) {
+                        if (iterator.hasNext()) {
+                          KeyValue<Long, Set<String>> current = iterator.next();
+                          current.value.add(span.name());
+                          if (!current.value.contains(span.name()))
+                            spanNamesStore.put(span.localServiceName(), current.value,
+                              timestamp);
+                        } else {
+                          Set<String> values = new LinkedHashSet<>();
+                          values.add(span.name());
+                          spanNamesStore.put(span.localServiceName(), values, timestamp);
+                        }
                       }
                     }
                     if (span.remoteServiceName() != null) { // store remote service names
-                      Set<String> remoteServiceNames =
-                          remoteServiceNamesStore.get(span.localServiceName());
-                      if (remoteServiceNames == null) remoteServiceNames = new LinkedHashSet<>();
-                      if (!remoteServiceNames.contains(span.remoteServiceName())) {
-                        remoteServiceNames.add(span.remoteServiceName());
-                        remoteServiceNamesStore.put(span.localServiceName(), remoteServiceNames);
+                      try (WindowStoreIterator<Set<String>> iterator =
+                             remoteServiceNamesStore.backwardFetch(span.localServiceName(), now.minusMillis(Duration.ofDays(7).toMillis()), now)) {
+                        if (iterator.hasNext()) {
+                          KeyValue<Long, Set<String>> current = iterator.next();
+                          if (!current.value.contains(span.remoteServiceName())) {
+                            current.value.add(span.remoteServiceName());
+                            remoteServiceNamesStore.put(span.localServiceName(), current.value,
+                              timestamp);
+                          }
+                        } else {
+                          Set<String> values = new LinkedHashSet<>();
+                          values.add(span.remoteServiceName());
+                          remoteServiceNamesStore.put(span.localServiceName(), values,
+                            timestamp);
+                        }
                       }
                     }
                   }
@@ -241,11 +209,19 @@ public class TraceStorageTopology implements Supplier<Topology> {
                     autoCompleteKeys.forEach(tagKey -> {
                       String value = span.tags().get(tagKey);
                       if (value != null) {
-                        Set<String> values = autocompleteTagsStore.get(tagKey);
-                        if (values == null) values = new LinkedHashSet<>();
-                        if (!values.contains(value)) {
-                          values.add(value);
-                          autocompleteTagsStore.put(tagKey, values);
+                        try (WindowStoreIterator<Set<String>> iterator =
+                               autocompleteTagsStore.backwardFetch(tagKey, now.minusMillis(Duration.ofDays(7).toMillis()), now)) {
+                          if (iterator.hasNext()) {
+                            KeyValue<Long, Set<String>> current = iterator.next();
+                            if (!current.value.contains(value)) {
+                              current.value.add(value);
+                              remoteServiceNamesStore.put(tagKey, current.value, timestamp);
+                            }
+                          } else {
+                            Set<String> values = new LinkedHashSet<>();
+                            values.add(value);
+                            remoteServiceNamesStore.put(tagKey, values, timestamp);
+                          }
                         }
                       }
                     });
@@ -256,7 +232,6 @@ public class TraceStorageTopology implements Supplier<Topology> {
               @Override public void close() {
               }
             },
-            SERVICE_NAMES_STORE_NAME,
             SPAN_NAMES_STORE_NAME,
             REMOTE_SERVICE_NAMES_STORE_NAME,
             AUTOCOMPLETE_TAGS_STORE_NAME);

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,25 +21,25 @@ class KafkaStorageBuilderTest {
 
   @Test void notSupported() {
     assertThatThrownBy(() -> KafkaStorage.newBuilder().strictTraceId(false))
-        .isInstanceOf(IllegalArgumentException.class);
+      .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test void buildDefaultBuilder() {
     KafkaStorageBuilder builder = KafkaStorage.newBuilder();
 
     assertThatThrownBy(() -> builder.spanPartitioning.spansTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.spanAggregation.spansTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.spanAggregation.traceTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.spanAggregation.dependencyTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.traceStorage.spansTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.dependencyStorage.dependencyTopic(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> builder.storageStateDir(null))
-        .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(NullPointerException.class);
   }
 }

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/DependencyStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/DependencyStorageTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +41,7 @@ class DependencyStorageTopologyTest {
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
     props.put(StreamsConfig.STATE_DIR_CONFIG,
-        "target/kafka-streams-test/" + System.currentTimeMillis());
+      "target/kafka-streams-test/" + System.currentTimeMillis());
   }
 
   @Test void should_doNothing_whenDisabled() {
@@ -50,10 +50,10 @@ class DependencyStorageTopologyTest {
     Duration dependenciesWindowSize = Duration.ofMillis(100);
     // When: topology created
     Topology topology = new DependencyStorageTopology(
-        dependencyTopic,
-        dependenciesRetentionPeriod,
-        dependenciesWindowSize,
-        false).get();
+      dependencyTopic,
+      dependenciesRetentionPeriod,
+      dependenciesWindowSize,
+      false).get();
     TopologyDescription description = topology.describe();
     // Then: topology with 1 thread
     assertThat(description.subtopologies()).hasSize(0);
@@ -68,10 +68,10 @@ class DependencyStorageTopologyTest {
     Duration dependenciesWindowSize = Duration.ofMillis(100);
     // When: topology created
     Topology topology = new DependencyStorageTopology(
-        dependencyTopic,
-        dependenciesRetentionPeriod,
-        dependenciesWindowSize,
-        true).get();
+      dependencyTopic,
+      dependenciesRetentionPeriod,
+      dependenciesWindowSize,
+      true).get();
     TopologyDescription description = topology.describe();
     // Then: topology with 1 thread
     assertThat(description.subtopologies()).hasSize(1);
@@ -79,11 +79,11 @@ class DependencyStorageTopologyTest {
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
     // When: a trace is passed
     ConsumerRecordFactory<String, DependencyLink> factory =
-        new ConsumerRecordFactory<>(dependencyTopic, new StringSerializer(),
-            dependencyLinkSerde.serializer());
+      new ConsumerRecordFactory<>(dependencyTopic, new StringSerializer(),
+        dependencyLinkSerde.serializer());
     DependencyLink dependencyLink = DependencyLink.newBuilder()
-        .parent("svc_a").child("svc_b").callCount(1).errorCount(0)
-        .build();
+      .parent("svc_a").child("svc_b").callCount(1).errorCount(0)
+      .build();
     String dependencyLinkId = "svc_a:svc_b";
     testDriver.pipeInput(factory.create(dependencyTopic, dependencyLinkId, dependencyLink, 10L));
     WindowStore<String, DependencyLink> links = testDriver.getWindowStore(DEPENDENCIES_STORE_NAME);

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/SpanAggregationTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/SpanAggregationTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The OpenZipkin Authors
+ * Copyright 2019-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,19 +14,18 @@
 package zipkin2.storage.kafka.streams;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.test.ConsumerRecordFactory;
-import org.apache.kafka.streams.test.OutputVerifier;
+import org.apache.kafka.streams.test.TestRecord;
 import org.junit.jupiter.api.Test;
 import zipkin2.DependencyLink;
 import zipkin2.Endpoint;
@@ -51,11 +50,11 @@ class SpanAggregationTopologyTest {
   @Test void should_doNothing_whenAggregationDisabled() {
     Duration traceTimeout = Duration.ofSeconds(1);
     Topology topology = new SpanAggregationTopology(
-        spansTopic,
-        traceTopic,
-        dependencyTopic,
-        traceTimeout,
-        false).get();
+      spansTopic,
+      traceTopic,
+      dependencyTopic,
+      traceTimeout,
+      false).get();
     TopologyDescription description = topology.describe();
     // Then: single threaded topology
     assertThat(description.subtopologies()).hasSize(0);
@@ -70,47 +69,47 @@ class SpanAggregationTopologyTest {
     DependencyLinkSerde dependencyLinkSerde = new DependencyLinkSerde();
     // When: topology built
     Topology topology = new SpanAggregationTopology(
-        spansTopic,
-        traceTopic,
-        dependencyTopic,
-        traceTimeout,
-        true).get();
+      spansTopic,
+      traceTopic,
+      dependencyTopic,
+      traceTimeout,
+      true).get();
     TopologyDescription description = topology.describe();
     // Then: single threaded topology
     assertThat(description.subtopologies()).hasSize(1);
     // Given: test driver
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
     // When: two related spans coming on the same Session window
-    ConsumerRecordFactory<String, List<Span>> factory =
-        new ConsumerRecordFactory<>(spansTopic, new StringSerializer(), spansSerde.serializer());
+    TestInputTopic<String, List<Span>> factory =
+      testDriver.createInputTopic(spansTopic, new StringSerializer(), spansSerde.serializer());
     Span a = Span.newBuilder().traceId("a").id("a").name("op_a").kind(Span.Kind.CLIENT)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
+      .build();
     Span b = Span.newBuilder().traceId("a").id("b").name("op_b").kind(Span.Kind.SERVER)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
-        .build();
-    testDriver.pipeInput(
-        factory.create(spansTopic, a.traceId(), Collections.singletonList(a), 0L));
-    testDriver.pipeInput(
-        factory.create(spansTopic, b.traceId(), Collections.singletonList(b), 0L));
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
+      .build();
+    factory.pipeInput(a.traceId(), Collections.singletonList(a), 0L);
+    factory.pipeInput(b.traceId(), Collections.singletonList(b), 0L);
     // When: and new record arrive, moving the event clock further than inactivity gap
     Span c = Span.newBuilder().traceId("c").id("c").build();
-    testDriver.pipeInput(factory.create(spansTopic, c.traceId(), Collections.singletonList(c),
-        traceTimeout.toMillis() + 1));
+    factory.pipeInput(c.traceId(), Collections.singletonList(c), traceTimeout.toMillis() + 1);
     // Then: a trace is aggregated.1
-    ProducerRecord<String, List<Span>> trace =
-        testDriver.readOutput(traceTopic, new StringDeserializer(), spansSerde.deserializer());
+    final TestOutputTopic<String, List<Span>> outputTopic =
+      testDriver.createOutputTopic(traceTopic, new StringDeserializer(), spansSerde.deserializer());
+    TestRecord<String, List<Span>> trace = outputTopic.readRecord();
     assertThat(trace).isNotNull();
-    OutputVerifier.compareKeyValue(trace, a.traceId(), Arrays.asList(a, b));
+    assertThat(trace.getKey()).isEqualTo(a.traceId());
+    assertThat(trace.getValue()).containsExactly(a, b);
     // Then: a dependency link is created
-    ProducerRecord<String, DependencyLink> linkRecord =
-        testDriver.readOutput(dependencyTopic, new StringDeserializer(),
-            dependencyLinkSerde.deserializer());
+    TestRecord<String, DependencyLink> linkRecord =
+      testDriver.createOutputTopic(dependencyTopic, new StringDeserializer(),
+        dependencyLinkSerde.deserializer()).readRecord();
     assertThat(linkRecord).isNotNull();
     DependencyLink link = DependencyLink.newBuilder()
-        .parent("svc_a").child("svc_b").callCount(1).errorCount(0)
-        .build();
-    OutputVerifier.compareKeyValue(linkRecord, "svc_a:svc_b", link);
+      .parent("svc_a").child("svc_b").callCount(1).errorCount(0)
+      .build();
+    assertThat(linkRecord.getKey()).isEqualTo("svc_a:svc_b");
+    assertThat(linkRecord.getValue()).isEqualTo(link);
     //Finally close resources
     testDriver.close();
     spansSerde.close();

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
@@ -16,22 +16,29 @@ package zipkin2.storage.kafka.streams;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.*;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.storage.kafka.streams.serdes.SpansSerde;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.AUTOCOMPLETE_TAGS_STORE_NAME;
-import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_IDS_BY_TS_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.TRACES_STORE_NAME;
 
@@ -43,7 +50,7 @@ class TraceStorageTopologyTest {
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
     props.put(StreamsConfig.STATE_DIR_CONFIG,
-        "target/kafka-streams-test/" + System.currentTimeMillis());
+      "target/kafka-streams-test/" + System.currentTimeMillis());
   }
 
   @Test void should_doNothing_whenAllDisabled() {
@@ -53,13 +60,13 @@ class TraceStorageTopologyTest {
     List<String> autocompleteKeys = Collections.singletonList("environment");
     // When: topology provided
     Topology topology = new TraceStorageTopology(
-        spansTopic,
-        autocompleteKeys,
-        traceTtl,
-        traceTtlCheckInterval,
-        0,
-        false,
-        false).get();
+      spansTopic,
+      autocompleteKeys,
+      traceTtl,
+      traceTtlCheckInterval,
+      0,
+      false,
+      false).get();
     TopologyDescription description = topology.describe();
     // Then:
     assertThat(description.subtopologies()).hasSize(0);
@@ -76,13 +83,13 @@ class TraceStorageTopologyTest {
     SpansSerde spansSerde = new SpansSerde();
     // When: topology provided
     Topology topology = new TraceStorageTopology(
-        spansTopic,
-        autocompleteKeys,
-        traceTtl,
-        traceTtlCheckInterval,
-        0,
-        true,
-        false).get();
+      spansTopic,
+      autocompleteKeys,
+      traceTtl,
+      traceTtlCheckInterval,
+      0,
+      true,
+      false).get();
     TopologyDescription description = topology.describe();
     // Then: 1 thread prepared
     assertThat(description.subtopologies()).hasSize(1);
@@ -90,38 +97,35 @@ class TraceStorageTopologyTest {
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
     // When: a trace is passed
     TestInputTopic<String, List<Span>> factory =
-        testDriver.createInputTopic(spansTopic, new StringSerializer(), spansSerde.serializer());
+      testDriver.createInputTopic(spansTopic, new StringSerializer(), spansSerde.serializer());
     Span a = Span.newBuilder().traceId("a").id("a").name("op_a").kind(Span.Kind.CLIENT)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
-        .timestamp(10000L).duration(11L)
-        .putTag("environment", "dev")
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
+      .timestamp(10000L).duration(11L)
+      .putTag("environment", "dev")
+      .build();
     Span b = Span.newBuilder().traceId("a").id("b").name("op_b").kind(Span.Kind.SERVER)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
-        .timestamp(10000L).duration(10L)
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
+      .timestamp(10000L).duration(10L)
+      .build();
     Span c = Span.newBuilder().traceId("c").id("c").name("op_a").kind(Span.Kind.CLIENT)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
-        .timestamp(10000L).duration(11L)
-        .putTag("environment", "dev")
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
+      .timestamp(10000L).duration(11L)
+      .putTag("environment", "dev")
+      .build();
     List<Span> spans = Arrays.asList(a, b, c);
     factory.pipeInput(a.traceId(), spans, 10L);
     // Then: trace stores are filled
-    KeyValueStore<String, List<Span>> traces = testDriver.getKeyValueStore(TRACES_STORE_NAME);
-    assertThat(traces.get(a.traceId())).containsExactlyElementsOf(spans);
-    KeyValueStore<Long, Set<String>> spanIdsByTs =
-        testDriver.getKeyValueStore(SPAN_IDS_BY_TS_STORE_NAME);
-    KeyValueIterator<Long, Set<String>> ids = spanIdsByTs.all();
-    assertThat(ids).hasNext();
-    assertThat(ids.next().value).containsExactly(a.traceId());
+    WindowStore<String, List<Span>> traces = testDriver.getWindowStore(TRACES_STORE_NAME);
+    try (final WindowStoreIterator<List<Span>> fetch = traces.fetch(a.traceId(), 0, 10000L)) {
+      assertThat(fetch.hasNext()).isTrue();
+      final KeyValue<Long, List<Span>> next = fetch.next();
+      assertThat(next.value).isEqualTo(spans);
+    }
     // Then: service name stores are filled
-    KeyValueStore<String, Set<String>> spanNames =
-        testDriver.getKeyValueStore(SPAN_NAMES_STORE_NAME);
+    WindowStore<String, Set<String>> spanNames = testDriver.getWindowStore(SPAN_NAMES_STORE_NAME);
     assertThat(spanNames).isNull();
-    KeyValueStore<String, Set<String>> autocompleteTags =
-        testDriver.getKeyValueStore(AUTOCOMPLETE_TAGS_STORE_NAME);
-    assertThat(autocompleteTags).isNull();
+    WindowStore<String, Set<String>> tags = testDriver.getWindowStore(AUTOCOMPLETE_TAGS_STORE_NAME);
+    assertThat(tags).isNull();
     // Finally close resources
     testDriver.close();
     spansSerde.close();
@@ -135,13 +139,13 @@ class TraceStorageTopologyTest {
     SpansSerde spansSerde = new SpansSerde();
     // When: topology provided
     Topology topology = new TraceStorageTopology(
-        spansTopic,
-        autocompleteKeys,
-        traceTtl,
-        traceTtlCheckInterval,
-        0,
-        true,
-        true).get();
+      spansTopic,
+      autocompleteKeys,
+      traceTtl,
+      traceTtlCheckInterval,
+      0,
+      true,
+      true).get();
     TopologyDescription description = topology.describe();
     // Then: 1 thread prepared
     assertThat(description.subtopologies()).hasSize(1);
@@ -149,57 +153,53 @@ class TraceStorageTopologyTest {
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
     // When: a trace is passed
     TestInputTopic<String, List<Span>> factory =
-        testDriver.createInputTopic(spansTopic, new StringSerializer(), spansSerde.serializer());
+      testDriver.createInputTopic(spansTopic, new StringSerializer(), spansSerde.serializer());
     Span a = Span.newBuilder().traceId("a").id("a").name("op_a").kind(Span.Kind.CLIENT)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
-        .timestamp(10000L).duration(11L)
-        .putTag("environment", "dev")
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
+      .timestamp(10000L).duration(11L)
+      .putTag("environment", "dev")
+      .build();
     Span b = Span.newBuilder().traceId("a").id("b").name("op_b").kind(Span.Kind.SERVER)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
-        .timestamp(10000L).duration(10L)
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_b").build())
+      .timestamp(10000L).duration(10L)
+      .build();
     Span c = Span.newBuilder().traceId("c").id("c").name("op_a").kind(Span.Kind.CLIENT)
-        .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
-        .timestamp(10000L).duration(11L)
-        .putTag("environment", "dev")
-        .build();
+      .localEndpoint(Endpoint.newBuilder().serviceName("svc_a").build())
+      .timestamp(10000L).duration(11L)
+      .putTag("environment", "dev")
+      .build();
     List<Span> spans = Arrays.asList(a, b, c);
     factory.pipeInput(a.traceId(), spans, 10L);
     // Then: trace stores are filled
-    KeyValueStore<String, List<Span>> traces = testDriver.getKeyValueStore(TRACES_STORE_NAME);
-    assertThat(traces.get(a.traceId())).containsExactlyElementsOf(spans);
-    KeyValueStore<Long, Set<String>> spanIdsByTs =
-        testDriver.getKeyValueStore(SPAN_IDS_BY_TS_STORE_NAME);
-    KeyValueIterator<Long, Set<String>> ids = spanIdsByTs.all();
-    assertThat(ids).hasNext();
-    assertThat(ids.next().value).containsExactly(a.traceId());
-    // FIXME: remove when test passes Then: service name stores are filled
-    //KeyValueStore<String, String> serviceNames =
-    //    testDriver.getKeyValueStore(SERVICE_NAMES_STORE_NAME);
-    //List<String> serviceNameList = new ArrayList<>();
-    //serviceNames.all().forEachRemaining(serviceName -> serviceNameList.add(serviceName.value));
-    //assertThat(serviceNameList).hasSize(2);
-    //assertThat(serviceNames.get("svc_a")).isEqualTo("svc_a");
-    //assertThat(serviceNames.get("svc_b")).isEqualTo("svc_b");
-    KeyValueStore<String, Set<String>> spanNames =
-        testDriver.getKeyValueStore(SPAN_NAMES_STORE_NAME);
-    assertThat(spanNames.get("svc_a")).containsExactly("op_a");
-    assertThat(spanNames.get("svc_b")).containsExactly("op_b");
-    KeyValueStore<String, Set<String>> autocompleteTags =
-        testDriver.getKeyValueStore(AUTOCOMPLETE_TAGS_STORE_NAME);
-    assertThat(autocompleteTags.get("environment")).containsExactly("dev");
-    // When: clock moves forward
-    Span d = Span.newBuilder()
-        .traceId("d")
-        .id("d")
-        .timestamp(
-            MILLISECONDS.toMicros(traceTtlCheckInterval.toMillis()) + MILLISECONDS.toMicros(20))
-        .build();
-    factory.pipeInput(d.traceId(), Collections.singletonList(d),
-        traceTtlCheckInterval.plusMillis(1).toMillis());
-    // Then: Traces store is empty
-    assertThat(traces.get(a.traceId())).isNull();
+    WindowStore<String, List<Span>> traces = testDriver.getWindowStore(TRACES_STORE_NAME);
+    try (final WindowStoreIterator<List<Span>> fetch = traces.fetch(a.traceId(), 0, 10000L)) {
+      assertThat(fetch.hasNext()).isTrue();
+      final KeyValue<Long, List<Span>> next = fetch.next();
+      assertThat(next.value).isEqualTo(spans);
+    }
+    WindowStore<String, Set<String>> spanNames = testDriver.getWindowStore(SPAN_NAMES_STORE_NAME);
+    Map<String, Set<String>> serviceNames = new HashMap<>();
+    try (
+      final KeyValueIterator<Windowed<String>, Set<String>> fetch = spanNames.fetchAll(0, 10000L)) {
+      while (fetch.hasNext()) {
+        final KeyValue<Windowed<String>, Set<String>> next = fetch.next();
+        serviceNames.put(next.key.key(), next.value);
+      }
+    }
+    assertThat(serviceNames).hasSize(2);
+    assertThat(serviceNames.keySet()).contains("svc_a", "svc_b");
+    assertThat(serviceNames.get("svc_a")).containsExactly("op_a");
+    assertThat(serviceNames.get("svc_b")).containsExactly("op_b");
+    WindowStore<String, Set<String>> tagsStore = testDriver.getWindowStore(AUTOCOMPLETE_TAGS_STORE_NAME);
+    Map<String, Set<String>> tags = new HashMap<>();
+    try (
+      final KeyValueIterator<Windowed<String>, Set<String>> fetch = tagsStore.fetchAll(0, 10010L)) {
+      while (fetch.hasNext()) {
+        final KeyValue<Windowed<String>, Set<String>> next = fetch.next();
+        tags.put(next.key.key(), next.value);
+      }
+    }
+    assertThat(tags.get("environment")).containsExactly("dev");
     // Finally close resources
     testDriver.close();
     spansSerde.close();

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
@@ -14,7 +14,6 @@
 package zipkin2.storage.kafka.streams;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +31,6 @@ import zipkin2.storage.kafka.streams.serdes.SpansSerde;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.AUTOCOMPLETE_TAGS_STORE_NAME;
-import static zipkin2.storage.kafka.streams.TraceStorageTopology.SERVICE_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_IDS_BY_TS_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.TRACES_STORE_NAME;
@@ -118,9 +116,6 @@ class TraceStorageTopologyTest {
     assertThat(ids).hasNext();
     assertThat(ids.next().value).containsExactly(a.traceId());
     // Then: service name stores are filled
-    KeyValueStore<String, String> serviceNames =
-        testDriver.getKeyValueStore(SERVICE_NAMES_STORE_NAME);
-    assertThat(serviceNames).isNull();
     KeyValueStore<String, Set<String>> spanNames =
         testDriver.getKeyValueStore(SPAN_NAMES_STORE_NAME);
     assertThat(spanNames).isNull();
@@ -179,14 +174,14 @@ class TraceStorageTopologyTest {
     KeyValueIterator<Long, Set<String>> ids = spanIdsByTs.all();
     assertThat(ids).hasNext();
     assertThat(ids.next().value).containsExactly(a.traceId());
-    // Then: service name stores are filled
-    KeyValueStore<String, String> serviceNames =
-        testDriver.getKeyValueStore(SERVICE_NAMES_STORE_NAME);
-    List<String> serviceNameList = new ArrayList<>();
-    serviceNames.all().forEachRemaining(serviceName -> serviceNameList.add(serviceName.value));
-    assertThat(serviceNameList).hasSize(2);
-    assertThat(serviceNames.get("svc_a")).isEqualTo("svc_a");
-    assertThat(serviceNames.get("svc_b")).isEqualTo("svc_b");
+    // FIXME: remove when test passes Then: service name stores are filled
+    //KeyValueStore<String, String> serviceNames =
+    //    testDriver.getKeyValueStore(SERVICE_NAMES_STORE_NAME);
+    //List<String> serviceNameList = new ArrayList<>();
+    //serviceNames.all().forEachRemaining(serviceName -> serviceNameList.add(serviceName.value));
+    //assertThat(serviceNameList).hasSize(2);
+    //assertThat(serviceNames.get("svc_a")).isEqualTo("svc_a");
+    //assertThat(serviceNames.get("svc_b")).isEqualTo("svc_b");
     KeyValueStore<String, Set<String>> spanNames =
         testDriver.getKeyValueStore(SPAN_NAMES_STORE_NAME);
     assertThat(spanNames.get("svc_a")).containsExactly("op_a");

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
@@ -38,6 +38,7 @@ import zipkin2.Span;
 import zipkin2.storage.kafka.streams.serdes.SpansSerde;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.AUTOCOMPLETE_TAGS_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.SPAN_NAMES_STORE_NAME;
 import static zipkin2.storage.kafka.streams.TraceStorageTopology.TRACES_STORE_NAME;
@@ -186,10 +187,11 @@ class TraceStorageTopologyTest {
         serviceNames.put(next.key.key(), next.value);
       }
     }
-    assertThat(serviceNames).hasSize(2);
-    assertThat(serviceNames.keySet()).contains("svc_a", "svc_b");
-    assertThat(serviceNames.get("svc_a")).containsExactly("op_a");
-    assertThat(serviceNames.get("svc_b")).containsExactly("op_b");
+    assertThat(serviceNames)
+      .hasSize(2)
+      .contains(
+        entry("svc_a", Collections.singleton("op_a")),
+        entry("svc_b", Collections.singleton("op_b")));
     WindowStore<String, Set<String>> tagsStore = testDriver.getWindowStore(AUTOCOMPLETE_TAGS_STORE_NAME);
     Map<String, Set<String>> tags = new HashMap<>();
     try (
@@ -199,7 +201,9 @@ class TraceStorageTopologyTest {
         tags.put(next.key.key(), next.value);
       }
     }
-    assertThat(tags.get("environment")).containsExactly("dev");
+    assertThat(tags)
+      .hasSize(1)
+      .contains(entry("environment", Collections.singleton("dev")));
     // Finally close resources
     testDriver.close();
     spansSerde.close();

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
@@ -67,7 +67,7 @@ class TraceStorageTopologyTest {
       false).get();
     TopologyDescription description = topology.describe();
     // Then:
-    assertThat(description.subtopologies()).hasSize(0);
+    assertThat(description.subtopologies()).isEmpty();
     // Given: streams config
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
     testDriver.close();
@@ -181,10 +181,10 @@ class TraceStorageTopologyTest {
     try (
       final KeyValueIterator<Windowed<String>, Set<String>> fetch = spanNames.fetchAll(0, 10000L)) {
       assertThat(fetch).hasNext();
-      assertThat(fetch).hasNext();
       assertThat(fetch.next())
         .extracting(next -> next.key.key(), next -> next.value)
         .containsExactly("svc_a", Collections.singleton("op_a"));
+      assertThat(fetch).hasNext();
       assertThat(fetch.next())
         .extracting(next -> next.key.key(), next -> next.value)
         .containsExactly("svc_b", Collections.singleton("op_b"));


### PR DESCRIPTION
[KIP-617](https://cwiki.apache.org/confluence/display/KAFKA/KIP-617%3A+Allow+Kafka+Streams+State+Stores+to+be+iterated+backwards) introduces backward iteration on all stores. 

This changes include:
- Migrating from key-value stores into window stores: by using windows, we remove the need to track traces->timestamp ourselves, and can use windowed keys that do this already.
- Reverse iteration solves the issue to iterate windows from oldest to newest, adding complexity to return latest results that match a query.
- Another side effect of using WindowStores instead of KeyValues is that we can use Window retention (remove old windows) to be handled by the library it self, instead of managing kv retention ourselves.

Testing:
While we wait for kafka2.7 to be release, we can test against its snapshot:

```
git clone git@github.com:apache/kafka
git checkout 2.7
./gradlewAll install
```