### PR TITLE
Changes naming convention of Docker to openzipkin-contrib

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -42,9 +42,9 @@ jobs:
         shell: bash
         env:
           CI: true
-      - name: Build Docker image openzipkincontrib/zipkin-storage-kafka:test
-        run: RELEASE_FROM_MAVEN_BUILD=true docker/build_image openzipkincontrib/zipkin-storage-kafka:test
-      - name: Verify Docker image openzipkincontrib/zipkin-storage-kafka:test
+      - name: Build Docker image openzipkin-contrib/zipkin-storage-kafka:test
+        run: RELEASE_FROM_MAVEN_BUILD=true docker/build_image openzipkin-contrib/zipkin-storage-kafka:test
+      - name: Verify Docker image openzipkin-contrib/zipkin-storage-kafka:test
         run: |
           # This just makes sure containers run and the HEALTHCHECK works (for now..)
           COMPOSE_FILE=.github/workflows/docker/docker-compose.test.yml

--- a/.github/workflows/docker/docker-compose.test.yml
+++ b/.github/workflows/docker/docker-compose.test.yml
@@ -25,7 +25,7 @@ services:
   # Use fixed service and container name 'sut; so our test script can copy/pasta
   sut:
     # This is the image just built. It is not in a remote repository.
-    image: openzipkincontrib/zipkin-storage-kafka:test
+    image: openzipkin-contrib/zipkin-storage-kafka:test
     container_name: sut
     ports:
       - 9411:9411

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: license-header
 ## Build test image
 .PHONY: docker-build-test
 docker-build-test:
-	docker/build_image openzipkincontrib/zipkin-storage-kafka:test
+	docker/build_image openzipkin-contrib/zipkin-storage-kafka:test
 ## Run test distributed compose
 .PHONY: docker-up-test
 docker-up-test:
@@ -28,7 +28,7 @@ docker-up-test:
 ## Build local image
 .PHONY: docker-build
 docker-build:
-	docker/build_image openzipkincontrib/zipkin-storage-kafka:latest
+	docker/build_image openzipkin-contrib/zipkin-storage-kafka:latest
 ## Run single instance compose
 .PHONY: docker-up-single
 docker-up-single:

--- a/README.md
+++ b/README.md
@@ -151,5 +151,5 @@ Snapshots are uploaded to [Sonatype](https://oss.sonatype.org/content/repositori
 commits to master.
 
 ### Docker Images
-Released versions of zipkin-server are published to Docker Hub as `openzipkincontrib/zipkin-storage-kafka` and GitHub
-Container Registry as `ghcr.io/openzipkincontrib/zipkin-storage-kafka`. See [docker](./docker) for details.
+Released versions of zipkin-storage-kafka are published to GitHub Container Registry as
+`ghcr.io/openzipkin-contrib/zipkin-storage-kafka`. See [docker](./docker) for details.

--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -36,7 +36,7 @@ case ${release_version} in
     minor_tag=$(echo "${release_version}" | cut -f1-2 -d. -s)
     subminor_tag="${release_version}"
     DOCKER_TAGS="$subminor_tag $minor_tag $major_tag latest"
-    DOCKER_REPOS="ghcr.io docker.io"
+    DOCKER_REPOS="ghcr.io"
     ;;
 esac
 
@@ -44,7 +44,7 @@ TAGS=""
 for repo in ${DOCKER_REPOS}; do
   TAGS="${TAGS}\n"
   for tag in ${DOCKER_TAGS}; do
-    TAGS="${TAGS} ${repo}/openzipkincontrib/zipkin-storage-kafka:${tag}"
+    TAGS="${TAGS} ${repo}/openzipkin-contrib/zipkin-storage-kafka:${tag}"
   done
 done
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,12 +9,12 @@ To build a zipkin-storage-kafka Docker image from source, in the top level of th
 
 
 ```bash
-$ docker/build_image openzipkincontrib/zipkin-storage-kafka:test
+$ docker/build_image openzipkin-contrib/zipkin-storage-kafka:test
 ```
 
 To build from a published version, run this instead:
 
 ```bash
-$ docker/build_image openzipkincontrib/zipkin-storage-kafka:test 0.18.1
+$ docker/build_image openzipkin-contrib/zipkin-storage-kafka:test 0.18.1
 ```
 

--- a/docker/build_image
+++ b/docker/build_image
@@ -29,7 +29,7 @@ GH_REPO=openzipkin-contrib/zipkin-storage-kafka
 # update .dockerignore if you ever add another here
 MODULE=storage-kafka
 DOCKER_TARGET=zipkin-${MODULE}
-TAG=${1:-openzipkincontrib/${DOCKER_TARGET}:test}
+TAG=${1:-openzipkin-contrib/${DOCKER_TARGET}:test}
 # Default the version to the pom when unset
 POM_VERSION=${POM_VERSION:-$(mvn help:evaluate -N -Dexpression=project.version -q -DforceStdout)}
 GROUP_ID=$(mvn help:evaluate -N -Dexpression=project.groupId -q -DforceStdout) || exit 1

--- a/docker/examples/dependencies/docker-compose.yml
+++ b/docker/examples/dependencies/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       kafka:
         condition: service_healthy
   zipkin:
-    image: ghcr.io/openzipkincontrib/zipkin-storage-kafka
+    image: ghcr.io/openzipkin-contrib/zipkin-storage-kafka
     container_name: zipkin
     hostname: zipkin # required to route call to scatter-gather endpoint properly. should not be needed after #40 is solved
     ports:

--- a/docker/examples/distributed/docker-compose.yml
+++ b/docker/examples/distributed/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       kafka:
         condition: service_healthy
   zipkin:
-    image: ghcr.io/openzipkincontrib/zipkin-kafka
+    image: ghcr.io/openzipkin-contrib/zipkin-kafka
     container_name: zipkin-aggregation
     ports:
       - 9411:9411
@@ -52,7 +52,7 @@ services:
       kafka-topics:
         condition: service_started
   zipkin-1:
-    image: ghcr.io/openzipkincontrib/zipkin-kafka
+    image: ghcr.io/openzipkin-contrib/zipkin-kafka
     container_name: zipkin-1
     hostname: zipkin-1
     ports:
@@ -68,7 +68,7 @@ services:
       kafka-topics:
         condition: service_started
   zipkin-2:
-    image: ghcr.io/openzipkincontrib/zipkin-kafka
+    image: ghcr.io/openzipkin-contrib/zipkin-kafka
     container_name: zipkin-2
     hostname: zipkin-2
     ports:

--- a/docker/examples/single/docker-compose.yml
+++ b/docker/examples/single/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       kafka:
         condition: service_healthy
   zipkin:
-    image: openzipkincontrib/zipkin-storage-kafka
+    image: openzipkin-contrib/zipkin-storage-kafka
     container_name: zipkin
     hostname: zipkin # required to route call to scatter-gather endpoint properly. should not be needed after #40 is solved
     ports:


### PR DESCRIPTION
Docker Hub registry doesn't like hyphens, but GitHub is our default
registry, and the org has to match the first part of the registry path.

This renames the docker images from openzipkincontrib/X to
openzipkin-contrib/X

While this is unfortunate, I think aligning names is better use of time
and attention in contrib vs publishing to two registries and have the
names conflict. Especially, as in the future ideally this will become a
non-contrib project anyway.