### PR TITLE
Moves all remaining logic that can be in build-bin from .travis.yml

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -1,14 +1,19 @@
 name: Continuous Build Docker
+
+# Trigger on pushes or pull requests to the master branch, but not for documentation-only updates.
 on:
   push:
-    branches:
-      - master
+    branches: master
+    paths-ignore: '**/*.md'
   pull_request:
+    branches: master
+    paths-ignore: '**/*.md'
 
 jobs:
   build-zipkin-storage-kafka:
     name: Build Zipkin Storage Kafka
     runs-on: ubuntu-20.04 # aka focal, because this is what we use in Travis
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,48 +49,27 @@ jobs:
         - ./build-bin/test || travis_terminate 1
         - if [ "${SHOULD_DEPLOY}" != "true" ]; then travis_terminate 0; fi
         # Deploy a SNAPSHOT version
-        - |
-          export POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)
-          # travis_wait ensures long pauses during uploads aren't mistaken for a hung job
-          travis_wait ./build-bin/deploy ${POM_VERSION}
+        # travis_wait ensures long pauses during uploads aren't mistaken for a hung job
+        - travis_wait ./build-bin/deploy
     - stage: deploy
       if: tag =~ /^[0-9]+\.[0-9]+\.[0-9]+$/ AND type = push AND env(GH_TOKEN) IS present
       name: Deploy a release
-      # verify the version tag is coherent
-      before_install: |
-        export POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)
-        if [ "${POM_VERSION}" != "${TRAVIS_TAG}" ]; then
-          echo "Invalid version. Git tag ${TRAVIS_TAG} should have project.version ${POM_VERSION}"
-          exit 1
-        fi
       install: ./build-bin/configure_deploy
       # travis_wait ensures long pauses during uploads aren't mistaken for a hung job
-      script: travis_wait ./build-bin/deploy ${POM_VERSION}
+      script: travis_wait ./build-bin/deploy
     # Create a release version when a release trigger and in a secure ENV
     - stage: create release
-      if: tag =~ /^release-[0-9]+\.[0-9]+\.[0-9]+$/ AND  type = push AND env(GH_TOKEN) IS present
+      if: tag =~ /^release-[0-9]+\.[0-9]+\.[0-9]+$/ AND type = push AND env(GH_TOKEN) IS present
       name: "Create release version"
       install: ./build-bin/git/login_git
-      script:
-        # Delete the trigger tag
-        - git push origin :"${TRAVIS_TAG}"
-        # Get the release version
-        - release_version=$(echo "${TRAVIS_TAG}" | sed 's/^release-//') || travis_terminate 1
-        # Create the release tag
-        - ./build-bin/maven/maven_prepare_release ${release_version}
+      script: build-bin/maven/maven_release ${TRAVIS_TAG}
     - stage: push docker
       if: tag =~ /^docker-[0-9]+\.[0-9]+\.[0-9]+$/ AND type = push AND env(GH_TOKEN) IS present
       name: Re-push all Docker images
       install:
         - ./build-bin/git/login_git
-        - ./build-bin/docker/configure_docker_push
-      script:
-        # Delete the trigger tag
-        - git push origin :"${TRAVIS_TAG}"
-        # Get the release version
-        - release_version=$(echo "${TRAVIS_TAG}" | sed 's/^docker-//') || travis_terminate 1
-        # Push the docker images
-        - ./build-bin/docker/docker_push ${release_version}
+        - ./build-bin/configure_docker_push
+      script: build-bin/docker_push ${TRAVIS_TAG}
 
 notifications:
   webhooks:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,13 +14,13 @@ This repo uses semantic versions. Please keep this in mind when choosing version
 
 1. **Wait for Travis CI**
 
-   The `release-N.M.L` tag triggers [`build-bin/maven/maven_prepare_release`](build-bin/maven/maven_prepare_release), which
-   creates commits, `N.M.L` tag, and increments the version (maven-release-plugin).
+   The `release-N.M.L` tag triggers [`build-bin/maven/maven_release`](build-bin/maven/maven_release),
+   which creates commits, `N.M.L` tag, and increments the version (maven-release-plugin).
 
    The `N.M.L` tag triggers [`build-bin/deploy`](build-bin/deploy), which does the following:
      * Publishes jars to https://oss.sonatype.org/content/repositories/releases [`build-bin/maven/maven_deploy`](build-bin/maven/maven_deploy)
        * Later, the same jars synchronize to Maven Central
-     * Pushes images to Docker registries [`build-bin/docker/docker_push`](build-bin/docker/docker_push)
+     * Pushes images to Docker registries [`build-bin/docker_push`](build-bin/docker_push)
 
    Notes:
      * https://search.maven.org/ index will take longer than direct links like https://repo1.maven.org/maven2/io/zipkin
@@ -78,11 +78,11 @@ export SONATYPE_PASSWORD=your_sonatype_password
 release_version=xx-version-to-release-xx
 
 # now from latest master, create the release. This creates and pushes the N.M.L tag
-./build-bin/maven/maven_prepare_release ${release_version}
+./build-bin/maven/maven_release release-${release_version}
 
 # once this works, deploy the release
 git checkout ${release_version}
-./build-bin/deploy ${release_version}
+./build-bin/deploy
 
 # Finally, clean up
 ./mvnw release:clean

--- a/build-bin/configure_docker_push
+++ b/build-bin/configure_docker_push
@@ -15,10 +15,12 @@
 
 set -ue
 
-# This script sets up anything needed for `./deploy`. Do not assume `configure_test` was called.
+# This script sets up anything needed for `./docker_push`.
 #
 # This script primarily helps `.travis.yml` and `RELEASE.md` contain nearly the same contents, even
 # if certain OpenZipkin projects need slight adjustments here.
 
-build-bin/maven/configure_maven_deploy
-build-bin/configure_docker_push
+# openzipkin-contrib is named differently in docker.io (openzipkincontrib). Skip the latter for now.
+export DOCKER_RELEASE_REPOS=ghcr.io
+export DOCKER_IMAGE=openzipkin-contrib/zipkin-storage-kafka
+build-bin/docker/configure_docker_push

--- a/build-bin/configure_test
+++ b/build-bin/configure_test
@@ -15,9 +15,8 @@
 
 set -ue
 
-# This script sets up anything needed to run tests in this project. This should not assume
-# `configure_test` was called at all. Nor should it login to anything, as that should be done in
-# `configure_deploy`.
+# This script sets up anything needed for `./test`. This should not login to anything, as that
+# should be done in `configure_deploy`.
 #
 # This script primarily helps `.travis.yml` and `RELEASE.md` contain nearly the same contents, even
 # if certain OpenZipkin projects need slight adjustments here.

--- a/build-bin/deploy
+++ b/build-bin/deploy
@@ -17,15 +17,17 @@ set -ue
 
 # This script deploys a SNAPSHOT or release version.
 #
-# Note: In CI, `configure_deploy` must be called before invoking this.
+# In CI..
+#  * trigger pattern for release: tag =~ /^[0-9]+\.[0-9]+\.[0-9]+$/
+#    * skip pull requests
+#  * trigger pattern for snapshot: tag IS blank AND commit_message !~ maven-release-plugin
+#    * skip documentation-only commits (paths-ignore: '**/*.md')
+#  * build-bin/configure_deploy must be called before invoking this.
 #
 # This script primarily helps `.travis.yml` and `RELEASE.md` contain nearly the same contents, even
 # if certain OpenZipkin projects need slight adjustments here.
 
-version=${1?version is required}
+version=${1-$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)}
 
 build-bin/maven/maven_deploy ${version}
-
-# openzipkin-contrib is named differently in docker.io (openzipkincontrib). Skip the latter for now.
-DOCKER_RELEASE_REPOS=ghcr.io RELEASE_FROM_MAVEN_BUILD=true build-bin/docker/docker_push \
-openzipkin-contrib/zipkin-storage-kafka ${version}
+RELEASE_FROM_MAVEN_BUILD=true build-bin/docker/docker_push ${version}

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -24,7 +24,7 @@ set -ue
 # Verify we are on an arch that can publish multi-arch images
 ARCH=$(uname -m)
 if [ "$ARCH" != "x86_64" ]; then
-  echo "multiarch/qemu-user-static doesn't support arch $ARCH"
+  >&2 echo "multiarch/qemu-user-static doesn't support arch $ARCH"
   exit 1
 fi
 

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -16,7 +16,7 @@
 set -ue
 
 if ! test -f docker/Dockerfile; then
-  echo Please execute this script from the repository root
+  >&2 echo Please execute this script from the repository root
   exit 1
 fi
 

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -21,12 +21,12 @@
 set -ue
 
 if ! test -f docker/Dockerfile; then
-  echo Please execute this script from the repository root
+  >&2 echo Please execute this script from the repository root
   exit 1
 fi
 
-docker_image=${1?docker_image is required. Ex openzipkin/zipkin}
-version=${2?version is required. Ex 1.2.3-SNAPSHOT or 2.22.2}
+docker_image=${DOCKER_IMAGE?required. Ex openzipkin/zipkin}
+version=${1?version is required. Ex 1.2.3-SNAPSHOT or 2.22.2}
 # Ex. "module" or "exec" Empty for no classifier.
 # optional classifier arg to ./build-bin/maven/maven_unjar if this image uses it. Allows you to
 # define a single image that builds two classifiers, which is the case in Zipkin (slim vs normal).
@@ -65,7 +65,7 @@ case ${arch} in
   amd64* )
     ;;
   * )
-    echo Pushing docker_platforms ${docker_platforms} with arch ${arch} is not yet supported.
+    >&2 echo Pushing docker_platforms ${docker_platforms} with arch ${arch} is not yet supported.
     exit 1
 esac
 

--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -15,10 +15,18 @@
 
 set -ue
 
-# This script sets up anything needed for `./deploy`. Do not assume `configure_test` was called.
+# This script pushes Docker images for the indicated version.
+#
+# In CI..
+#  * trigger pattern: tag =~ /^docker-[0-9]+\.[0-9]+\.[0-9]+$/
+#    * skip pull requests
+#  * build-bin/git/login_git must be called before invoking this.
+#  * build-bin/configure_docker_push must be called before invoking this.
 #
 # This script primarily helps `.travis.yml` and `RELEASE.md` contain nearly the same contents, even
 # if certain OpenZipkin projects need slight adjustments here.
 
-build-bin/maven/configure_maven_deploy
-build-bin/configure_docker_push
+trigger_tag=${1?trigger_tag is required. Ex docker-1.2.3}
+version=$(build-bin/git/version_from_trigger_tag docker- ${trigger_tag})
+
+build-bin/docker/docker_push ${version}

--- a/build-bin/git/version_from_trigger_tag
+++ b/build-bin/git/version_from_trigger_tag
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Copyright 2019-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -ue
+
+# This script echos a `N.M.L` version tag based on..
+#  * arg1: XXXXX- prefix
+#  * arg2: XXXXX-N.M.L git trigger tag
+#
+# The script exits 1 if the prefix doesn't match. On success, the tag is deleted if it exists.
+#
+# Note: In CI, `build-bin/git/login_git` must be called before invoking this.
+
+trigger_tag_prefix=${1?required. Ex docker- to match docker-1.2.3}
+trigger_tag=${2?trigger_tag is required. Ex ${trigger_tag_prefix}1.2.3}
+
+# Checking sed output to determine success as exit code handling in sed or awk is awkward
+version=$(echo "${trigger_tag}" | sed -En "s/^${trigger_tag_prefix}([0-9]+\.[0-9]+\.[0-9]+)$/\1/p")
+
+if [ -z "$version" ]; then
+  >&2 echo invalid trigger tag: ${trigger_tag}
+  exit 1;
+fi
+
+# try to cleanup the trigger tag if it exists, but don't fail if it doesn't
+git tag -d ${trigger_tag} 2>&- >&- || true
+git push origin :${trigger_tag} 2>&- >&- || true
+
+echo $version

--- a/build-bin/maven/maven_release
+++ b/build-bin/maven/maven_release
@@ -15,21 +15,26 @@
 
 set -ue
 
-# This script creates a release tag N.N.N which later will have `deploy` run against it.
+# This script creates a git `N.M.L` version tag which later will have `deploy` run against it.
 #
-# Note: In CI, `build-bin/git/login_git` must be called before invoking this.
-release_version=${1?release_version is required. Ex 2.22.2}
+# In CI..
+#  * trigger pattern: tag =~ /^release-[0-9]+\.[0-9]+\.[0-9]+$/
+#  * build-bin/git/login_git must be called before invoking this.
+
+trigger_tag=${1?trigger_tag is required. Ex release-1.2.3}
+release_version=$(build-bin/git/version_from_trigger_tag release- ${trigger_tag})
 release_branch=${2:-master}
 
 # Checkout master, as we release from master, not a tag ref
 git checkout -B ${release_branch}
+exit
 
 # Ensure no one pushed commits since this release tag as it would fail later commands
 git fetch origin ${release_branch}:origin/${release_branch}
 commit_local_release_branch=$(git show --pretty='format:%H' ${release_branch})
 commit_remote_release_branch=$(git show --pretty='format:%H' origin/${release_branch})
 if [ "$commit_local_release_branch" != "$commit_remote_release_branch" ]; then
-  echo "${release_branch} on remote 'origin' has commits since the version under release, aborting"
+  >&2 echo "${release_branch} on remote 'origin' has commits since the version to release, aborting"
   exit 1
 fi
 

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -80,7 +80,7 @@ else
 fi
 
 if ! test -f ${artifact_id}.jar; then
-  echo "*** Failed to build or get ${qualified_jar}"
+  >&2 echo "*** Failed to build or get ${qualified_jar}"
   exit 1
 fi
 

--- a/build-bin/test
+++ b/build-bin/test
@@ -17,7 +17,10 @@ set -ue
 
 # This script runs the tests of the project.
 #
-# Note: In CI, `configure_test` must be called before invoking this.
+# In CI..
+#  * trigger pattern: tag IS blank AND commit_message !~ maven-release-plugin
+#    * skip documentation-only commits (paths-ignore: '**/*.md')
+#  * build-bin/configure_test must be called before invoking this.
 #
 # This script primarily helps `.travis.yml` and `RELEASE.md` contain nearly the same contents, even
 # if certain OpenZipkin projects need slight adjustments here.

--- a/pom.xml
+++ b/pom.xml
@@ -374,17 +374,20 @@
                 <docker_push>SCRIPT_STYLE</docker_push>
                 <!-- build-bin/git -->
                 <login_git>SCRIPT_STYLE</login_git>
+                <version_from_trigger_tag>SCRIPT_STYLE</version_from_trigger_tag>
                 <!-- build-bin/maven -->
                 <configure_maven>SCRIPT_STYLE</configure_maven>
                 <configure_maven_deploy>SCRIPT_STYLE</configure_maven_deploy>
                 <maven_build_or_unjar>SCRIPT_STYLE</maven_build_or_unjar>
                 <maven_deploy>SCRIPT_STYLE</maven_deploy>
-                <maven_prepare_release>SCRIPT_STYLE</maven_prepare_release>
+                <maven_release>SCRIPT_STYLE</maven_release>
                 <maven_unjar>SCRIPT_STYLE</maven_unjar>
                 <!-- build-bin -->
                 <configure_deploy>SCRIPT_STYLE</configure_deploy>
+                <configure_docker_push>SCRIPT_STYLE</configure_docker_push>
                 <configure_test>SCRIPT_STYLE</configure_test>
                 <deploy>SCRIPT_STYLE</deploy>
+                <docker_push>SCRIPT_STYLE</docker_push>
                 <test>SCRIPT_STYLE</test>
               </mapping>
               <excludes>


### PR DESCRIPTION
4 days after raising a support issue, our Travis setup in openzipkin is
still dead. This moves all portable logic out of .travis.yml in case we
need to switch to GitHub Actions deployment.