### PR TITLE
Update container URL to beta.zipkin.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ commits to master.
 
 ### Docker Images
 Released versions of zipkin-storage-kafka are published to GitHub Container Registry as
-`ghcr.io/openzipkin-contrib/zipkin-storage-kafka`. See [docker](./docker) for details.
+`beta.zipkin.io/openzipkin-contrib/zipkin-storage-kafka`. See [docker](./docker) for details.

--- a/docker/examples/dependencies/docker-compose.yml
+++ b/docker/examples/dependencies/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       kafka:
         condition: service_healthy
   zipkin:
-    image: ghcr.io/openzipkin-contrib/zipkin-storage-kafka
+    image: beta.zipkin.io/openzipkin-contrib/zipkin-storage-kafka
     container_name: zipkin
     hostname: zipkin # required to route call to scatter-gather endpoint properly. should not be needed after #40 is solved
     ports:

--- a/docker/examples/single/docker-compose.yml
+++ b/docker/examples/single/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       kafka:
         condition: service_healthy
   zipkin:
-    image: openzipkin-contrib/zipkin-storage-kafka
+    image: beta.zipkin.io/openzipkin-contrib/zipkin-storage-kafka
     container_name: zipkin
     hostname: zipkin # required to route call to scatter-gather endpoint properly. should not be needed after #40 is solved
     ports:


### PR DESCRIPTION
This PR updates the README and docker compose files to use the new beta.zipkin.io domain. From doing a search this appears to be the only spots we pull from ghcr.io currently, but please do let me know if I'm missing anything!