### PR TITLE
Update all license header for year 2021

### DIFF
--- a/build-bin/docker/configure_docker
+++ b/build-bin/docker/configure_docker
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_block_on_health
+++ b/build-bin/docker/docker_block_on_health
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_test_image
+++ b/build-bin/docker/docker_test_image
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/git/login_git
+++ b/build-bin/git/login_git
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/git/version_from_trigger_tag
+++ b/build-bin/git/version_from_trigger_tag
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/gpg/configure_gpg
+++ b/build-bin/gpg/configure_gpg
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_deploy
+++ b/build-bin/maven/maven_deploy
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_go_offline
+++ b/build-bin/maven/maven_go_offline
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_opts
+++ b/build-bin/maven/maven_opts
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_release
+++ b/build-bin/maven/maven_release
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/dependencies/docker-compose.yml
+++ b/docker/examples/dependencies/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/distributed/docker-compose.yml
+++ b/docker/examples/distributed/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/single/docker-compose.yml
+++ b/docker/examples/single/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019-2020 The OpenZipkin Authors
+    Copyright 2019-2021 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
+++ b/module/src/main/java/zipkin2/module/storage/kafka/ZipkinKafkaStorageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/module/src/test/java/zipkin2/module/storage/kafka/Access.java
+++ b/module/src/test/java/zipkin2/module/storage/kafka/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/module/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageModuleTest.java
+++ b/module/src/test/java/zipkin2/storage/kafka/ZipkinKafkaStorageModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019-2020 The OpenZipkin Authors
+    Copyright 2019-2021 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaAutocompleteTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageHttpService.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaStorageHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreScatterGatherListCall.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreScatterGatherListCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreSingleKeyListCall.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/internal/KafkaStoreSingleKeyListCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStorageTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/SpanAggregationTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStorageTopology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/test/java/zipkin2/storage/kafka/ITKafkaStorage.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/ITKafkaStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/DependencyStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/DependencyStorageTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/SpanAggregationTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/SpanAggregationTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/streams/TraceStorageTopologyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenZipkin Authors
+ * Copyright 2019-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
I ran into CI issues with https://github.com/openzipkin-contrib/zipkin-storage-kafka/pull/84, due to copyright year in the headers being out of date. After updating just the files I touched in that PR, CI was still complaining about all the other files, so this PR updates the copyright year globally to this project.